### PR TITLE
Simpify parsing of query part of URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
@@ -1,3 +1,11 @@
+---
+name: New Goal Suggestion
+about: Suggest a new goal to be added
+title: "[NEW GOAL]"
+labels: New Goal
+assignees: Joshimuz
+
+---
 **Name of the Goal**
 What should the name of the Goal be? This is the text that is used inside the squares on the sheet
 

--- a/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
@@ -1,0 +1,45 @@
+---
+name: New Goal Suggestion
+about: Suggest a new goal to be added
+title: "[NEW GOAL]"
+labels: New Goal
+assignees: Joshimuz
+
+---
+
+**Name of the Goal**
+What should the name of the Goal be? This is the text that is used inside the squares on the sheet
+
+The name should be purely factual, describe clearly what the goal should be (no funny names) and leave no doubt in the player's mind what they need or can do. EG: "Do a cool jump off a hill" doesn't explain what a "cool jump" is, or even what a "hill" is.
+The name should also be as short as possible for ease of reading as well as size limitations. If the name needs to be too long to explain every detail then add a Tooltip and shorten the name.
+Goals that require gathering of items can simply be the Items Name with a number (or a range) if it should be multiple. Like: "(2-10) Feathers"
+
+**Tooltip for the Goal**
+What should the Tooltip for this Goal be, if anything?
+
+The Tooltip should be purely factual, and only explain details that can't be explained within the name.
+Try to keep the wording as short as possible.
+
+**Tooltip Image**
+What should the Image for the Tooltip be? Either link or attach an image here.
+
+Every Tooltip should have an image.
+The image should be 64x64 and a .jpg, and help explain the goal visually.
+
+**Difficulty level**
+What Difficulty from Very Easy to Very Hard should the Goal be?
+
+Try to think about what other goals are in that difficulty and what they require like how hard it is to do, how rare it is and how long it takes. For example Goals that require going to the End or finding a Mushroom Field aren't a good fit for Medium or below.
+
+**Anti Synergies and Catalysts/Reactants**
+What other preexisting Goals shouldn't be on the same sheet as this Goal?
+
+Try to list any Goals that would be impossible or very hard to do with this Goal. For example: "Never Sleep" and "Sleep in a Village" should never be on the same sheet as it's impossible to do both, and "Never Use an Axe" makes "Stripped Oak Logs" a lot harder, if not impossible.
+
+**Why this Goal is good**
+What do you think is good about this Goal?
+
+Is it cool or funny? Like: "Kill yourself with your own arrow"
+Does it teach the player about an interesting or niche game mechanic? Like:
+Will it force players to think carefully about their plan? Like: "Never Use Coal"
+Or is it just a simple goal that fits the Difficulty well? Like: "Iron Block" for Very Easy

--- a/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
@@ -6,13 +6,13 @@ The name should also be as short as possible for ease of reading as well as size
 Goals that require gathering of items can simply be the Items Name with a number (or a range) if it should be multiple. Like: "(2-10) Feathers"*
 
 **Tooltip for the Goal**
-*What should the Tooltip for this Goal be, if anything?
+What should the Tooltip for this Goal be, if anything?
 
-The Tooltip should be purely factual, and only explain details that can't be explained within the name.
+*The Tooltip should be purely factual, and only explain details that can't be explained within the name.
 Try to keep the wording as short as possible.*
 
 **Tooltip Image**
-*What should the Image for the Tooltip be? Either link or attach an image here.*
+What should the Image for the Tooltip be? Either link or attach an image here.
 
 *Every Tooltip should have an image.
 The image should be 64x64 and a .jpg, and help explain the goal visually.*

--- a/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-goal-suggestion.md
@@ -1,45 +1,36 @@
----
-name: New Goal Suggestion
-about: Suggest a new goal to be added
-title: "[NEW GOAL]"
-labels: New Goal
-assignees: Joshimuz
-
----
-
 **Name of the Goal**
 What should the name of the Goal be? This is the text that is used inside the squares on the sheet
 
-The name should be purely factual, describe clearly what the goal should be (no funny names) and leave no doubt in the player's mind what they need or can do. EG: "Do a cool jump off a hill" doesn't explain what a "cool jump" is, or even what a "hill" is.
+*The name should be purely factual, describe clearly what the goal should be (no funny names) and leave no doubt in the player's mind what they need or can do. EG: "Do a cool jump off a hill" doesn't explain what a "cool jump" is, or even what a "hill" is.
 The name should also be as short as possible for ease of reading as well as size limitations. If the name needs to be too long to explain every detail then add a Tooltip and shorten the name.
-Goals that require gathering of items can simply be the Items Name with a number (or a range) if it should be multiple. Like: "(2-10) Feathers"
+Goals that require gathering of items can simply be the Items Name with a number (or a range) if it should be multiple. Like: "(2-10) Feathers"*
 
 **Tooltip for the Goal**
-What should the Tooltip for this Goal be, if anything?
+*What should the Tooltip for this Goal be, if anything?
 
 The Tooltip should be purely factual, and only explain details that can't be explained within the name.
-Try to keep the wording as short as possible.
+Try to keep the wording as short as possible.*
 
 **Tooltip Image**
-What should the Image for the Tooltip be? Either link or attach an image here.
+*What should the Image for the Tooltip be? Either link or attach an image here.*
 
-Every Tooltip should have an image.
-The image should be 64x64 and a .jpg, and help explain the goal visually.
+*Every Tooltip should have an image.
+The image should be 64x64 and a .jpg, and help explain the goal visually.*
 
 **Difficulty level**
 What Difficulty from Very Easy to Very Hard should the Goal be?
 
-Try to think about what other goals are in that difficulty and what they require like how hard it is to do, how rare it is and how long it takes. For example Goals that require going to the End or finding a Mushroom Field aren't a good fit for Medium or below.
+*Try to think about what other goals are in that difficulty and what they require like how hard it is to do, how rare it is and how long it takes. For example Goals that require going to the End or finding a Mushroom Field aren't a good fit for Medium or below.*
 
 **Anti Synergies and Catalysts/Reactants**
 What other preexisting Goals shouldn't be on the same sheet as this Goal?
 
-Try to list any Goals that would be impossible or very hard to do with this Goal. For example: "Never Sleep" and "Sleep in a Village" should never be on the same sheet as it's impossible to do both, and "Never Use an Axe" makes "Stripped Oak Logs" a lot harder, if not impossible.
+*Try to list any Goals that would be impossible or very hard to do with this Goal. For example: "Never Sleep" and "Sleep in a Village" should never be on the same sheet as it's impossible to do both, and "Never Use an Axe" makes "Stripped Oak Logs" a lot harder, if not impossible.*
 
 **Why this Goal is good**
 What do you think is good about this Goal?
 
-Is it cool or funny? Like: "Kill yourself with your own arrow"
+*Is it cool or funny? Like: "Kill yourself with your own arrow"
 Does it teach the player about an interesting or niche game mechanic? Like:
 Will it force players to think carefully about their plan? Like: "Never Use Coal"
-Or is it just a simple goal that fits the Difficulty well? Like: "Iron Block" for Very Easy
+Or is it just a simple goal that fits the Difficulty well? Like: "Iron Block" for Very Easy*

--- a/bingo.js
+++ b/bingo.js
@@ -555,17 +555,19 @@ function getRandomInt(min, max)
 	return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-// gup source: www.netlobo.com/url_query_string_javascript.html
+// https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 function gup( name )
 {
-  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
-  var regexS = "[\\?&]"+name+"=([^&#]*)";
-  var regex = new RegExp( regexS );
-  var results = regex.exec( window.location.href );
-  if( results == null )
-    return "";
-  else
-    return results[1];
+	let params = new URLSearchParams(document.location.search.substring(1));
+	let result = params.get(name);
+	if (result == null)
+	{
+		return "";
+	}
+	else
+	{
+		return result;
+	}
 }
 
 // random source: www.engin33r.net/bingo/random.js


### PR DESCRIPTION
Usage of RegExp to parse the query part of the URL has been replaced with [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).
I've manually tested this change in Firefox 85 and Chromium 88, by comparing local to [minecraftbingo.com](https://minecraftbingo.com).