### PR TITLE
clean up name of the "Ominous Banner" goal

### DIFF
--- a/goals_v4.js
+++ b/goals_v4.js
@@ -364,7 +364,7 @@ var bingoList_v4 = [
 	{name: "Ignite a TNT with a Lectern", tags: [Action, Overworld]},
 	{name: "Kill a hostile mob with a Sweet Berry Bush", reactant: ["Pacifist"], tags: [Action, Overworld, Combat, RareBiome]},
 	{name: "Get a Pillager's Crossbow", reactant: ["Pacifist"], tooltiptext: "Kill Pillagers until you get a rare drop from one, it being their Crossbow", tags: [Item, Combat, Overworld]},
-	{name: "Ominous Banner‌", reactant: ["Pacifist"], tags: [Item, Combat, Overworld]},
+	{name: "Ominous Banner", reactant: ["Pacifist"], tags: [Item, Combat, Overworld]},
 	{name: "Gain a Fox's Trust", tags: [Action, Overworld, RareBiome]},
 	{name: "1 Honey Block", antisynergy: ["Honey"], frequency: 2, tags: [Action, Overworld]},
 	{name: "3 Honeycomb Blocks", antisynergy: ["Honeycomb"], frequency: 2, tags: [Action, Overworld]},


### PR DESCRIPTION
Remove a curly quotes character which may not be visible in browsers,
depending on encoding settings,  from the string 'name' of the "Ominous
Banner" goal.  This character [appears as "â€Œ" in some encodings](https://stackoverflow.com/a/48046018/1083697). This
is the only instance, that I found.


----

The broken name in `/index.html?s=3-0-0-dev_89078` looks like this: 

![image](https://user-images.githubusercontent.com/624072/110102393-06144680-7da5-11eb-8464-6843647b7fab.png)
