### PR TITLE
Reformatted rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,38 +105,36 @@
 		<a class="stream-exit-text" href="#" onclick='popoutBingoCard();'>Pop out Bingo Card</a>
 		<section id="rules-section">
 			<h2>Version</h2>
-			<p>Versions of the Bingo are designed for certain versions of Vanilla Minecraft. Try to match versions whenever possible for the best experience.</p>
+			<p>The various versions of the Bingo are designed for specific versions of Vanilla Minecraft (Java Edition, Bedrock versions have minor differences). Try to match versions whenever possible for the best experience.</p>
 			<p>To ensure that each created Bingo sheet always stays the same (even if goals are added or modified in the future) a version identifier is encoded into the URL.</p>
 			<p>Selected version: <select id="version_selection"></select></p>
 
 			<p id="version_notice">You are not using the latest stable version. This may be intended, for example if you want to look at a linked sheet or play on an older version of Minecraft. However, if you want to generate a new Bingo sheet, consider changing version.</p>
 			<p id="version_notice_unstable">You are using an in-development version which may change at any time causing the same link to produce different goals. This is good if you want to make use of the latest updates to goals and Minecraft and for looking at a sheet someone else just linked to you, otherwise consider changing to a stable version.</p>
-			<p><em>Note:</em> The goals are designed for the Java Edition of Minecraft, Bedrock versions have minor differences in some areas.</p>
 
 			<h2>How to Play</h2>
 
-			<p>The objective is to get a "Bingo" as quickly as possible by filling in five squares in a line horizontally, vertically or diagonally.</p>
-			<p>Each square has a goal written inside of it which you have to complete. There are 4 types of goals:</p>
-
-			<h4>Items</h4>
-				<li>Goals written as just Item names (such as "Iron Block" or "Milk Bucket") require you to get that item and have it in your Inventory at the end of the game.</li>
-				<li><em>Note:</em> If you lose the item by completing the Bingo by dying (e.g. "Kill yourself with an Ender Pearl" as the last goal) you do not need to recollect the item.</li>
-			<h4>Actions</h4>
-				<li>If the goal describes an action (for example "Tame a Wolf"), the goal is completed once you Tame the Wolf. It doesn't matter what happens to the Wolf after.</li>
-			<h4>Builds</h4>
-				<li>For goals which ask you to place something in the Minecraft world (like "Build a 2x2x2 leaf cube"), you must make sure that the build does not get destroyed for the duration of the Bingo.</li>
-				<li><em>Note:</em> You don't have to show the build at the end, so if you didn't see it get destroyed it counts.</li>
-			<h4>Stats</h4>
-				<li>Goals which list stats (such as "Crouch a distance of 50 meters") make use of the Statistics screen in the Minecraft pause menu. You need to ensure that stat shows the given amount (or greater).</li>
-				<li><em>Tip:</em> The Statistics screen often updates slowly, so leave some time between checking it when you're trying to complete a goal.</li>
-			<p></p>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button onclick='copySeedToClipboard("seed_for_copying_howto");'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
-			<p>If you're racing together with other players, generate a Bingo sheet and then link it to them so that everyone has the same goals. You can hide the table in the Options menu before generating the seed so that everyone can reveal the sheet when you start. Make sure everyone uses the same Seed for the world too!</p>
+			<p>The objective is to get a "Bingo" as quickly as possible by completing the goals in five squares in a line horizontally, vertically or diagonally.</p>
+			<ul>
+				<li><strong>Items:</strong> Goals written as just Item names (such as "Iron Block" or "Milk Bucket") require you to get that item and have it in your Inventory at the end of the game. If you lose the item by completing the Bingo by dying (e.g. "Kill yourself with an Ender Pearl" as the last goal) you do not need to recollect the item.</li>
+				<li><strong>Actions:</strong> If the goal describes an action (for example "Tame a Wolf"), the goal is completed once you Tame the Wolf. It doesn't matter what happens to the Wolf after.</li>
+				<li><strong>Builds:</strong> For goals which ask you to place something in the Minecraft world (like "Build a 2x2x2 leaf cube"), you must make sure that the build does not get destroyed for the duration of the Bingo. You don't have to show the build at the end, so if you didn't see it get destroyed it counts.</li>
+				<li><strong>Stats:</strong> Goals which list stats (such as "Crouch a distance of 50 meters") make use of the Statistics screen in the Minecraft pause menu. You need to ensure that stat shows the given amount (or greater). The Statistics screen often updates slowly, so leave some time between checking it when you're trying to complete a goal.</li>
+			</ul>
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (0-6)!</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
+			<h3>Creating the World</h3>
+			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button onclick='copySeedToClipboard("seed_for_copying_howto");'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
-			<p><em>Note:</em> This is only the recommended way to play Minecraft Bingo, if you and/or everyone else agrees then use whatever rules you want!</p>
-			<p><em>Tip:</em> You can <a href="javascript:createGoalExport()">export the current sheet as JSON</a> for use in other tools such as <a href="https://bingosync.com/">Bingosync.</a></p>
+
+			<h3>Playing with Others</h3>
+			<p>If you're racing together with other players, generate a Bingo sheet and then link it to them so that everyone has the same goals. You can hide the table in the Options menu before generating the seed so that everyone can reveal the sheet when you start. Make sure everyone uses the same Seed for the world too!</p>
+			
+			<h2>Other</h2>
+			
+			<p>These rules (and goal descriptions) represent the recommended way to play Minecraft Bingo, however if you play alone or everyone in the race agress, then use whatever rules you want!</p>
+			<p>You can <a href="javascript:createGoalExport()">export the current sheet as JSON</a> for use in other tools such as <a href="https://bingosync.com/">Bingosync.</a></p>
 			<a href="https://github.com/Joshimuz/mcbingo"><img src="github-img.png" width='200px'></a>
 		</section>
 		<div id="tooltip">


### PR DESCRIPTION
The new rules are good, but I think it could use some improvements:

* The version section has "designed for" twice, so combined that into one sentence.
* The description of the different types of goals a bit less cluttered. A proper list, instead of just list items. Having headings for the different types makes sense, but I think having one list item for each type makes it more readable.
* Adding headings for the other sections, moved some stuff around that belongs logically together (e.g. tips for marking goals should be next to the section about goals).
* Too many "Tips" and "Notes" that they kind of loose some meaning of "look, this is important", so removed some of these prefixes or integrated the information otherwise.