### PR TITLE
Overhaul tooltip icon visibility

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -237,10 +237,6 @@ html, body {
 	background:#a77039;
 }
 
-#bingo td img {
-	visibility: hidden;
-}
-
 #hidden-table {
 	font-family: settingsFont;
 	background-color: white;
@@ -283,6 +279,9 @@ html, body {
 	padding-top: 4px;
 	right: 5px;
 	top: 5px;
+}
+#bingo td[data-tooltiptext=""] .tooltipQ {
+	display: none;
 }
 
 /* End Bingo Card  */

--- a/bingo.js
+++ b/bingo.js
@@ -36,6 +36,7 @@ var VERSIONS = [
 var LATEST_VERSION = "3";
 
 const SQUARE_COUNT = 25;
+const NODE_TYPE_TEXT = 3;
 
 // Dropdown menu handling.
 $(document).click(function(event) {
@@ -315,7 +316,7 @@ function generateNewSheet()
 	
 	// Reset every goal square
 	forEachSquare((i, square) => {
-		square.contents().filter(function(){ return this.nodeType == 3; }).remove();
+		square.contents().filter(function(){ return this.nodeType == NODE_TYPE_TEXT; }).remove();
 		square.data("tooltipimg", "");
 		square.data("tooltiptext", "");
 		square.children().css("visibility", "hidden");

--- a/bingo.js
+++ b/bingo.js
@@ -321,12 +321,7 @@ function generateNewSheet()
 		square.data("tooltipimg", "");
 		square.data("tooltiptext", "");
 		square.children().css("visibility", "hidden");
-		square.removeClass('greensquare');
-		square.removeClass('redsquare');
-		square.removeClass('bluesquare');
-		square.removeClass('yellowsquare');
-		square.removeClass('pinksquare');
-		square.removeClass('brownsquare');
+		setSquareColor(square, "");
 	});
 
 	var result = VERSION.generator(LAYOUT, DIFFICULTY, VERSION.goals);

--- a/bingo.js
+++ b/bingo.js
@@ -20,7 +20,7 @@ var hoveredSquare;
 // either rename the current unstable version (and then maybe create files
 // for a new unstable version) or create new files/a new entry for the
 // release.
-// 
+//
 // The version is a string, so theoretically it doesn't have to just be
 // numbers (although maybe just numbers would be better).
 //
@@ -218,8 +218,8 @@ $(document).ready(function()
 	});
 
 
-	window.onpopstate = function(event) 
-	{ 
+	window.onpopstate = function(event)
+	{
 		getSettingsFromURL();
 	};
 	
@@ -276,7 +276,7 @@ function getSettingsFromURL()
 		// Set the layout settings' text
 		// document.getElementById("whatlayout").innerHTML="Set Layout";
 	}
-	else 
+	else
 	{
 		LAYOUT = "random";
 		// document.getElementById("whatlayout").innerHTML="Random Layout";
@@ -288,7 +288,7 @@ function getSettingsFromURL()
 	generateNewSheet();
 }
 
-function generateNewSheet() 
+function generateNewSheet()
 {
 	$(".seed_for_copying").val(SEED);
 	$(".seed_for_copying").attr("size", SEED.length);
@@ -364,7 +364,7 @@ function newSeed(remakeSheet)
 }
 
 // Change the layout
-function changeLayout() 
+function changeLayout()
 {	
 	// Change the layout based on the current layout
 	if (LAYOUT == "set")
@@ -373,8 +373,8 @@ function changeLayout()
 		
 		// Update the button's text
 		document.getElementById("whatlayout").innerHTML="Set Layout";
-	} 
-	else 
+	}
+	else
 	{
 		LAYOUT = "set";
 		
@@ -408,7 +408,7 @@ function updateHidden()
 	}
 }
 
-function toggleHidden() 
+function toggleHidden()
 {
 	// Invert HIDDEN setting, then update
 	HIDDEN = !HIDDEN;
@@ -602,7 +602,7 @@ function hideGoalExport()
 }
 
 // Made this a function for readability and ease of use
-function getRandomInt(min, max) 
+function getRandomInt(min, max)
 {
 	return Math.floor(Math.random() * (max - min + 1)) + min;
 }

--- a/bingo.js
+++ b/bingo.js
@@ -136,8 +136,9 @@ $(document).ready(function()
 	$("#bingo td img").hover(function()
 	{
 		var tooltipImg = $(this).parent().data("tooltipimg");
+		var tooltipText = $(this).parent().data("tooltiptext");
 		// If the tooltip is empty
-		if ($(this).parent().data("tooltiptext") == "" && tooltipImg == "")
+		if (tooltipText == "" && tooltipImg == "")
 		{
 			// Do nothing lol
 		}
@@ -147,7 +148,7 @@ $(document).ready(function()
 			 $("#tooltip").show();
 			 $("#tooltipimg").attr('src', tooltipImg);
 			 $("#tooltipimg").toggle(tooltipImg != "");
-			 $("#tooltiptext").text($(this).parent().data("tooltiptext"));
+			 $("#tooltiptext").text(tooltipText);
 		}
 	},function()
 	{

--- a/bingo.js
+++ b/bingo.js
@@ -231,10 +231,6 @@ $(document).ready(function()
 	$(".colourCount-text").text(COLOURCOUNTTEXT[COLOURCOUNT]);
 })
 
-/* When the user clicks on the button, 
-toggle between hiding and showing the dropdown content */
-
-
 function getSettingsFromURL()
 {
 	/**

--- a/bingo.js
+++ b/bingo.js
@@ -37,6 +37,8 @@ var LATEST_VERSION = "3";
 
 const SQUARE_COUNT = 25;
 const NODE_TYPE_TEXT = 3;
+const TOOLTIP_TEXT_ATTR_NAME = "data-tooltiptext";
+const TOOLTIP_IMAGE_ATTR_NAME = "data-tooltipimg";
 
 // Dropdown menu handling.
 $(document).click(function(event) {
@@ -318,9 +320,6 @@ function generateNewSheet()
 	// Reset every goal square
 	forEachSquare((i, square) => {
 		square.contents().filter(function(){ return this.nodeType == NODE_TYPE_TEXT; }).remove();
-		square.data("tooltipimg", "");
-		square.data("tooltiptext", "");
-		square.children().css("visibility", "hidden");
 		setSquareColor(square, "");
 	});
 
@@ -332,22 +331,8 @@ function generateNewSheet()
 		//square.append(goal.generatedName + " " + goal.difficulty);
 		square.append(goal.generatedName);
 		
-		if (typeof goal.tooltipimg !== 'undefined')
-		{
-			square.data("tooltipimg", goal.tooltipimg);
-			if (!HIDDEN)
-			{
-				square.children().css("visibility", "visible");
-			}
-		}
-		if (typeof goal.tooltiptext !== 'undefined')
-		{
-			square.data("tooltiptext", goal.tooltiptext);
-			if (!HIDDEN)
-			{
-				square.children().css("visibility", "visible");
-			}
-		}
+		square.attr(TOOLTIP_TEXT_ATTR_NAME, goal.tooltiptext || "");
+		square.attr(TOOLTIP_IMAGE_ATTR_NAME, goal.tooltipimg || "");
 	});
 }
 

--- a/bingo.js
+++ b/bingo.js
@@ -35,6 +35,8 @@ var VERSIONS = [
 // This is the newest stable version that users not specifying a version will get
 var LATEST_VERSION = "3";
 
+const SQUARE_COUNT = 25;
+
 // Dropdown menu handling.
 $(document).click(function(event) {
 	if (event.target.className.includes('dropdown-button')) {
@@ -288,6 +290,21 @@ function getSettingsFromURL()
 	generateNewSheet();
 }
 
+/*
+ * Call given function for every square. The given function shall take two arguments:
+ * 1. an index
+ * 2. the square's element
+ */
+function forEachSquare(f)
+{
+	for (var i = 0; i < SQUARE_COUNT; i++)
+	{
+		var slotId = "#slot"+ (i + 1);
+		var square = $(slotId);
+		f(i, square);
+	}
+}
+
 function generateNewSheet()
 {
 	$(".seed_for_copying").val(SEED);
@@ -297,48 +314,44 @@ function generateNewSheet()
 	Math.seedrandom(SEED);
 	
 	// Reset every goal square
-	for (var i=0; i<=24; i++) 
-	{
-		var slotId = "#slot"+ (i + 1);
-		$(slotId).contents().filter(function(){ return this.nodeType == 3; }).remove();
-		$(slotId).data("tooltipimg", "");
-		$(slotId).data("tooltiptext", "");
-		$(slotId).children().css("visibility", "hidden");
-		$(slotId).removeClass('greensquare');
-		$(slotId).removeClass('redsquare');
-		$(slotId).removeClass('bluesquare');
-		$(slotId).removeClass('yellowsquare');
-		$(slotId).removeClass('pinksquare');
-		$(slotId).removeClass('brownsquare');
-	}
+	forEachSquare((i, square) => {
+		square.contents().filter(function(){ return this.nodeType == 3; }).remove();
+		square.data("tooltipimg", "");
+		square.data("tooltiptext", "");
+		square.children().css("visibility", "hidden");
+		square.removeClass('greensquare');
+		square.removeClass('redsquare');
+		square.removeClass('bluesquare');
+		square.removeClass('yellowsquare');
+		square.removeClass('pinksquare');
+		square.removeClass('brownsquare');
+	});
 
 	var result = VERSION.generator(LAYOUT, DIFFICULTY, VERSION.goals);
 	
-	for (var i=0; i<25; i++)
-	{
-		var slotId = "#slot"+ (i + 1);
+	forEachSquare((i, square) => {
 		var goal = result[i];
 
-		//$(slotId).append(goal.generatedName + " " + goal.difficulty);
-		$(slotId).append(goal.generatedName);
+		//square.append(goal.generatedName + " " + goal.difficulty);
+		square.append(goal.generatedName);
 		
 		if (typeof goal.tooltipimg !== 'undefined')
 		{
-			$(slotId).data("tooltipimg", goal.tooltipimg);
+			square.data("tooltipimg", goal.tooltipimg);
 			if (!HIDDEN)
 			{
-				$(slotId).children().css("visibility", "visible");
+				square.children().css("visibility", "visible");
 			}
 		}
 		if (typeof goal.tooltiptext !== 'undefined')
 		{
-			$(slotId).data("tooltiptext", goal.tooltiptext);
+			square.data("tooltiptext", goal.tooltiptext);
 			if (!HIDDEN)
 			{
-				$(slotId).children().css("visibility", "visible");
+				square.children().css("visibility", "visible");
 			}
 		}
-	}
+	});
 }
 
 // Create a new seed
@@ -584,14 +597,12 @@ function copySeedToClipboard(id)
 function createGoalExport()
 {
 	let result = [];
-	for (var i=0; i<25; i++)
-	{
-		var slotId = "#slot"+ (i + 1);
+	forEachSquare((i, square) => {
 		result.push({
-			name: $(slotId).text(),
-			tooltip: $(slotId).data("tooltiptext")
+			name: square.text(),
+			tooltip: square.data("tooltiptext")
 		});
-	}
+	});
 	$("#export textarea").text(JSON.stringify(result));
 	$("#export").show();
 }

--- a/generator_v1.js
+++ b/generator_v1.js
@@ -71,7 +71,7 @@ var generator_v1 = function(layout, difficulty, bingoList)
 						
 		function distributeDifficulty(amountOfDifficulty, difficulty)
 		{
-			for (var i = 0; i < amountOfDifficulty; i++) 
+			for (var i = 0; i < amountOfDifficulty; i++)
 			{
 				var cont = true;
 				
@@ -99,9 +99,9 @@ var generator_v1 = function(layout, difficulty, bingoList)
 		distributeDifficulty(amountOfMedium, 1);
 	}
 	
-	for (var i=0; i<=24; i++) 
+	for (var i=0; i<=24; i++)
 	{		
-		do 
+		do
 		{
 			var cont = true;
 			
@@ -143,7 +143,7 @@ var generator_v1 = function(layout, difficulty, bingoList)
 		var goal = JSON.parse(JSON.stringify(goalCandidate)); // Clone object
 
 		// Replace random ranges in goal name
-		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input) 
+		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input)
 		{
 			n1 = parseInt(n1);
 			n2 = parseInt(n2);

--- a/generator_v2.js
+++ b/generator_v2.js
@@ -71,7 +71,7 @@ var generator_v2 = function(layout, difficulty, bingoList)
 						
 		function distributeDifficulty(amountOfDifficulty, difficulty)
 		{
-			for (var i = 0; i < amountOfDifficulty; i++) 
+			for (var i = 0; i < amountOfDifficulty; i++)
 			{
 				var cont = true;
 				var failSafe = 0;
@@ -106,11 +106,11 @@ var generator_v2 = function(layout, difficulty, bingoList)
 		distributeDifficulty(amountOfEasy, 1);
 	}
 	
-	for (var i=0; i<=24; i++) 
+	for (var i=0; i<=24; i++)
 	{		
 		var failSafe = 0;
 		
-		do 
+		do
 		{
 			var cont = true;
 			failSafe++;
@@ -179,7 +179,7 @@ var generator_v2 = function(layout, difficulty, bingoList)
 		var goal = JSON.parse(JSON.stringify(goalCandidate)); // Clone object
 
 		// Replace random ranges in goal name
-		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input) 
+		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input)
 		{
 			n1 = parseInt(n1);
 			n2 = parseInt(n2);

--- a/generator_v3.js
+++ b/generator_v3.js
@@ -71,7 +71,7 @@ var generator_v3 = function(layout, difficulty, bingoList)
 						
 		function distributeDifficulty(amountOfDifficulty, difficulty)
 		{
-			for (var i = 0; i < amountOfDifficulty; i++) 
+			for (var i = 0; i < amountOfDifficulty; i++)
 			{
 				var cont = true;
 				var failSafe = 0;
@@ -106,11 +106,11 @@ var generator_v3 = function(layout, difficulty, bingoList)
 		distributeDifficulty(amountOfEasy, 1);
 	}
 	
-	for (var i=0; i<=24; i++) 
+	for (var i=0; i<=24; i++)
 	{		
 		var failSafe = 0;
 		
-		do 
+		do
 		{
 			//console.log("Starting do while loop: " + counter);
 			counter++;
@@ -226,7 +226,7 @@ var generator_v3 = function(layout, difficulty, bingoList)
 		var goal = JSON.parse(JSON.stringify(goalCandidate)); // Clone object
 
 		// Replace random ranges in goal name
-		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input) 
+		goal.generatedName = goal.name.replace(/\((\d+)-(\d+)\)/g, function(match, n1, n2, offset, input)
 		{
 			n1 = parseInt(n1);
 			n2 = parseInt(n2);

--- a/goals_v1.js
+++ b/goals_v1.js
@@ -1,6 +1,6 @@
 // This file should not be edited anymore since a stable version refers to it (except
 // maybe for purely visual things that don't change the goals, like typos).
-// 
+//
 // These goals are at the state of this commit (2017-07-08):
 // https://github.com/Joshimuz/mcbingo/commit/d48049bf973a3d9757af69c8dc38ad626334c507
 
@@ -90,7 +90,7 @@ var bingoList_v1 = [
 	{name: "Kill a Creeper with only fire"},
 ],
 
-// Medium (1) 
+// Medium (1)
 [
 	{name: "Wither Skull"},
 	{name: "(6-8) Different Edible Items"},

--- a/goals_v2.js
+++ b/goals_v2.js
@@ -130,7 +130,7 @@ var bingoList_v2 = [
 	{name: "(33-64) Redstone", antisynergy: "Redstone", frequency: 2},
 ],
 
-// Medium (2) 
+// Medium (2)
 [
 	{name: "Wither Skull"},
 	{name: "(6-8) Different Edible Items"},

--- a/goals_v3.js
+++ b/goals_v3.js
@@ -204,7 +204,7 @@ var bingoList_v3 = [
 	{name: "(4-5) Different Edible Items", tooltiptext: "Raw and cooked variants count as one (e.g. Raw Beef and Steak)", tooltipimg: "Goal Tooltip Images/RawAndCooked.jpg", antisynergy: "EdibleItems", frequency: 2},
 ],
 
-// Medium (2) 
+// Medium (2)
 [
 	{name: "Wither Skull"},
 	{name: "(6-7) Different Edible Items", tooltiptext: "Raw and cooked variants count as one (e.g. Raw Beef and Steak)", tooltipimg: "Goal Tooltip Images/RawAndCooked.jpg", antisynergy: "EdibleItems", frequency: 2},

--- a/goals_v4.js
+++ b/goals_v4.js
@@ -1,17 +1,17 @@
 // This is part of a version currently in development and may be changed at any time.
 
 // Tags
-var Item = {name: "Item", max: [25, 25, 20, 20, 20]}, 
-Stat = {name: "Stat", max: [5, 5, 5, 5, 5]}, 
-Action = {name: "Action", max: [20, 20, 20, 20, 20]}, 
-Build = {name: "Build", max: [20, 20, 20, 20, 20]}, 
-RareBiome = {name: "RareBiome", max: [0, 1, 2, 4, 6]}, 
-Ocean = {name: "Ocean", max: [5, 5, 5, 5, 5]}, 
-Village = {name: "Village", max: [0, 1, 2, 3, 4]}, 
-Colour = {name: "Colour", max: [2, 2, 2, 2, 2]}, 
-Never = {name: "Never", max: [3, 3, 3, 2, 1]}, 
-Combat = {name: "Combat", max: [5, 10, 20, 20, 20]}, 
-Overworld = {name: "Overworld", max: [25, 25, 24, 21, 18]}, 
+var Item = {name: "Item", max: [25, 25, 20, 20, 20]},
+Stat = {name: "Stat", max: [5, 5, 5, 5, 5]},
+Action = {name: "Action", max: [20, 20, 20, 20, 20]},
+Build = {name: "Build", max: [20, 20, 20, 20, 20]},
+RareBiome = {name: "RareBiome", max: [0, 1, 2, 4, 6]},
+Ocean = {name: "Ocean", max: [5, 5, 5, 5, 5]},
+Village = {name: "Village", max: [0, 1, 2, 3, 4]},
+Colour = {name: "Colour", max: [2, 2, 2, 2, 2]},
+Never = {name: "Never", max: [3, 3, 3, 2, 1]},
+Combat = {name: "Combat", max: [5, 10, 20, 20, 20]},
+Overworld = {name: "Overworld", max: [25, 25, 24, 21, 18]},
 Nether = {name: "Nether", max: [0, 2, 5, 10, 15]},
 End = {name: "End", max: [0, 0, 0, 1, 5]};
 
@@ -107,7 +107,7 @@ var bingoList_v4 = [
 	{name: "(16-64) Flint", tags: [Item]},
 	{name: "Cake", tags: [Item, Overworld]},
 	{name: "Pumpkin Pie", tags: [Item, Overworld]},
-	{name: "Fish a Treasure and a Junk item", tooltiptext: "Treasure: Bow, Enchanted Book, Name Tag, Nautilus Shell, Saddle. Junk: Lily Pad, Bowl, Leather, Boots, Rotten Flesh, Stick, Water Bottle, Bone, Ink Sac, Tripwire Hook", reactant: ["Fishing", "Pacifist"], tags: [Action, Overworld]}, 
+	{name: "Fish a Treasure and a Junk item", tooltiptext: "Treasure: Bow, Enchanted Book, Name Tag, Nautilus Shell, Saddle. Junk: Lily Pad, Bowl, Leather, Boots, Rotten Flesh, Stick, Water Bottle, Bone, Ink Sac, Tripwire Hook", reactant: ["Fishing", "Pacifist"], tags: [Action, Overworld]},
 	{name: "(16-64) Coarse Dirt", tags: [Item, Overworld]},
 	{name: "(2-3) Clocks", tags: [Item, Overworld]},
 	{name: "(2-4) Iron Blocks", antisynergy: ["IronBlocks"], frequency: 2, tags: [Item]},
@@ -257,7 +257,7 @@ var bingoList_v4 = [
 	{name: "(3-6) Coal Blocks", tags: [Item]},
 ],
 
-// Medium (2) 
+// Medium (2)
 [
 	{name: "(6-7) Different Edible Items", tooltiptext: "Raw and cooked variants count as one (e.g. Raw Beef and Steak)", tooltipimg: "Goal Tooltip Images/RawAndCooked.jpg", antisynergy: ["EdibleItems"], frequency: 2, tags: [Item, Overworld]},
 	//{name: "(8-10) Different Gold Items", antisynergy: ["GoldItems"], tooltiptext: "Any item with 'Gold' in its name (yes even ingots and ores)", tags: [Item]},


### PR DESCRIPTION
The last commit of this pull ruquest fixes a bug introduced in fa40258 (currently in `dev`, but not in `master`). Other commits are code cleanup and refactoring. See also https://clips.twitch.tv/ObservantSuspiciousBunnySquadGoals-IgoZFMA-alnr5UWe

Steps to reproduce the bug:

  1. Open a URL with a hidden table setting, for example `index.html?s=4-1-0-dev_89001`
  2. Click "Show Table"
  3. Observe the squares which are supposed to have tooltips, e.g. "Activate a 5x4 Nether Portal (not counting corners)"