### PR TITLE
Fix tooltips not updating

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -137,8 +137,8 @@ $(document).ready(function()
 	// On hovering a goal square
 	$("#bingo td img").hover(function()
 	{
-		var tooltipImg = $(this).parent().data("tooltipimg");
-		var tooltipText = $(this).parent().data("tooltiptext");
+		var tooltipImg = $(this).parent().attr(TOOLTIP_IMAGE_ATTR_NAME);
+		var tooltipText = $(this).parent().attr(TOOLTIP_TEXT_ATTR_NAME);
 		// If the tooltip is empty
 		if (tooltipText == "" && tooltipImg == "")
 		{
@@ -581,7 +581,7 @@ function createGoalExport()
 	forEachSquare((i, square) => {
 		result.push({
 			name: square.text(),
-			tooltip: square.data("tooltiptext")
+			tooltip: square.attr(TOOLTIP_TEXT_ATTR_NAME)
 		});
 	});
 	$("#export textarea").text(JSON.stringify(result));

--- a/bingo.js
+++ b/bingo.js
@@ -146,11 +146,7 @@ $(document).ready(function()
 		}
 		else
 		{
-			// Show the tooltip and fill it with content from the goal
 			 $("#tooltip").show();
-			 $("#tooltipimg").attr('src', tooltipImg);
-			 $("#tooltipimg").toggle(tooltipImg != "");
-			 $("#tooltiptext").text(tooltipText);
 		}
 	},function()
 	{
@@ -179,6 +175,12 @@ $(document).ready(function()
 	$("#bingo td").hover(function(e)
 	{
 		hoveredSquare = $(this);
+		// Fill the #tooltip with the content from the goal
+		var tooltipImg = hoveredSquare.attr(TOOLTIP_IMAGE_ATTR_NAME);
+		var tooltipText = hoveredSquare.attr(TOOLTIP_TEXT_ATTR_NAME);
+		$("#tooltipimg").attr('src', tooltipImg);
+		$("#tooltipimg").toggle(tooltipImg != "");
+		$("#tooltiptext").text(tooltipText);
 	},function(e)
 	{
 		hoveredSquare = null;

--- a/bingo.js
+++ b/bingo.js
@@ -137,17 +137,7 @@ $(document).ready(function()
 	// On hovering a goal square
 	$("#bingo td img").hover(function()
 	{
-		var tooltipImg = $(this).parent().attr(TOOLTIP_IMAGE_ATTR_NAME);
-		var tooltipText = $(this).parent().attr(TOOLTIP_TEXT_ATTR_NAME);
-		// If the tooltip is empty
-		if (tooltipText == "" && tooltipImg == "")
-		{
-			// Do nothing lol
-		}
-		else
-		{
-			 $("#tooltip").show();
-		}
+		$("#tooltip").show();
 	},function()
 	{
 		// After hovering, hide the tooltip again


### PR DESCRIPTION
A bug was introduced in commit 48ce64b (hide .tooltipQ using CSS attribute rule, 2021-03-07):

### Steps to reproduce

1. Generate random seed until a goal with a tooltip appears.
2. Hover over a tooltip. Remember the position of the square.
3. Generate random seeds until another sheet with a tooltip in the same square appears.
4. Hover over the tooltip in the same square as in step #2.
5. Click "export the current sheet as JSON"
6. Observe the tooltip for the same square in the export.

### Actual results
- In steps 4 and 6 the tooltip corresponds to the goal from the second step.

### Expected results
- In steps 4 and 6 the tooltip corresponds to the goal of the shown square.

### Notes
Here's a patch which makes testing easier: [testing-tooltips.patch.txt](https://github.com/Joshimuz/mcbingo/files/6098110/testing-tooltips.patch.txt). It adds a button "Debug seed", which a) forces Medium difficulty and b) allows switching between two seeds with tooltips in the second goal of the bottom row.

----

Commit 969c4b1 fixes the bug. A separate visual glitch is fixed in commit 4269e41. Commit bea12e0 is code cleanup.






