### PR TITLE
Clean up CSS for #rules-section

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -451,27 +451,33 @@ body.streamer-mode {
 	text-align: center;
 }
 
-#rules-section p, h2, h3, ul, li {
+#rules-section p,
+#rules-section h2,
+#rules-section h3,
+#rules-section ul,
+#rules-section ul li {
 	max-width: 800px;
 	text-align: left;
 	margin-left: auto;
 	margin-right: auto;
 	padding: 5px;
-	list-style-type: circle;
+}
+#rules-section h2,
+#rules-section h3 {
+	text-align: center;
 }
 
 #rules-section ul {
 	padding-left: 60px;
+}
+#rules-section ul li {
+	list-style-type: circle;
 }
 
 #rules-section a {
 	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
-}
-
-#rules-section h2, h3 {
-	text-align: center;
 }
 
 /* End Rules And Bottom */


### PR DESCRIPTION
Only the first CSS selectors of CSS rules for the rules `<section>` have been created with the #rules-section selector, which might cause issues in the future.

Add missing selectors to make the rules more specific.  Move `<li>` tag specific declaration into a separate CSS rule.  Reorder rules, so that `<h2>` and `<h3>` rules are higher than `<ul>` rules.  Note, that this doesn't change the design of the page, just makes the CSS more robust to possible future additions of affected tags.
