### PR TITLE
Use jQuery version 1.11.1 explicitly

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<title>Minecraft Bingo</title>
 		<link rel="stylesheet" href="bingo.css" type="text/css" />
 		
-		<script src="https://code.jquery.com/jquery-latest.js"></script>
+		<script src="https://code.jquery.com/jquery-1.11.1.js"></script>
 		
 		<script src="generator_v1.js"></script>
 		<script src="generator_v2.js"></script>


### PR DESCRIPTION
Per [jQuery blogpost](https://blog.jquery.com/2014/07/03/dont-use-jquery-latest-js/) it is not recommended to use the file     `jquery-latest.js`.  Switch explicitly to jQuery 1.11.1 for now, which is identical to the currently used `jquery-latest.js`, which was frozen by the jQuery project at version 1.11.1.

Quotes from blog post:

> So let’s be clear: Don’t use jquery-latest.js on a production site.
> [...]
> As jQuery adoption has continued to grow, even that safeguard seems insufficient to protect against careless use of http://code.jquery.com/jquery-latest.js. So we have decided to stop updating this file, as well as the minified copy, keeping both files at version 1.11.1 forever.
> [...]
> However, note that [jquery-latest.js] currently has a very short cache time, which means you’re losing the performance benefit of of a long cache time that the CDN provides when you request a full version like 1.11.1 instead.

Migrating to a newer version of jQuery would take a lot of testing, so let's just use 1.11.1 for now, and migrate later.