### PR TITLE
function generateNewSheet() has been taught to highlight "Never" goals at the start

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -8,6 +8,7 @@ var VERSION;
 var DIFFICULTYTEXT = [ "Very Easy", "Easy", "Medium", "Hard", "Very Hard"];
 var COLOURCOUNT = 1;
 var COLOURCOUNTTEXT = [ "Green only", "Blue, Green, Red", "6 Colours"];
+const NEVER_HIGHLIGHT_CLASS_NAME = "greensquare";
 
 var hoveredSquare;
 
@@ -342,6 +343,11 @@ function generateNewSheet()
 
 		square.attr(TOOLTIP_TEXT_ATTR_NAME, goal.tooltiptext || "");
 		square.attr(TOOLTIP_IMAGE_ATTR_NAME, goal.tooltipimg || "");
+
+		if (goal.tags && goal.tags.findIndex(t => t.name == "Never") != -1)
+		{
+			setSquareColor(square, NEVER_HIGHLIGHT_CLASS_NAME);
+		}
 	});
 }
 


### PR DESCRIPTION
Goals with tag "Never" are always completed at the very start at the
game.  Playtesting has shown that players sometimes don't notice the
"Never" goals and lock themselves out of them before reading the sheet
completely.

Most people use green to signify completion of a goal.  So highlight all
the "Never" goals as if they are already completed when the sheet is
generated.  Another argument for the green colour is that it is the
colour available in all colour count options.

----

Demo:

https://user-images.githubusercontent.com/624072/110696541-809cf600-81eb-11eb-9fee-3bb33070d367.mp4

