### PR TITLE
Change width and height of the window popout in Streamer Mode to hide scrollbars

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -374,7 +374,7 @@ function toggleHidden()
 }
 
 function popoutBingoCard(){
-    window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=728, height=665");
+    window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=745, height=700");
 }
 
 function toggleStreamerMode()

--- a/bingo.js
+++ b/bingo.js
@@ -374,7 +374,7 @@ function toggleHidden()
 }
 
 function popoutBingoCard(){
-    window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=745, height=700");
+    window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=745, height=705");
 }
 
 function toggleStreamerMode()


### PR DESCRIPTION
Tested in Chrome and Firefox.