### PR TITLE
Tooltips have been added to the "Copy Seed" buttons

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -261,6 +261,7 @@ html, body {
 }
 
 #hidden-table-seed button {
+	margin-top: 10px;
 	width: 200px;
 }
 
@@ -323,6 +324,12 @@ html, body {
 	font-family: settingsFont;
 	text-align: center;
 }
+.small-button {
+	padding: 3px;
+	height: auto;
+	font-size: 1em;
+}
+
 .versions-button {
 	width: 50px;
 }

--- a/bingo.css
+++ b/bingo.css
@@ -85,26 +85,44 @@ html, body {
 	border: 4px solid;
 }
 
-#tooltip {
+.tooltip {
 	position: absolute;
 	margin: 20px;
 	display: inline-block;
-	width: 300px;
 	border: 2px solid purple;
 	background-color: rgba(0,0,0,.9);
-	padding: 10px;
 	font-family: settingsFont;
 	text-align: center;
-	line-height: 1.2em;
 }
 
-#tooltip img {
+.tooltiptext {
+	border-radius: 5px;
+	text-shadow: 2px 2px #000;
+	font-size: 12px;
+	color: #FFF;
+	overflow: hidden;
+}
+
+#goalTooltip {
+	padding: 10px;
+	width: 300px;
+}
+
+#goalTooltip img {
 	border: 2px solid #EBEBEB;
 	margin-right: 5px;
 	width: 64px;
 	height: 64px;
 	float: left;
 	background-color: #C6C6C6;
+}
+
+#goalTooltip .tooltiptext {
+	line-height: 1.2em;
+	margin-bottom: 40px;
+	margin-left: 10px;
+	position: relative;
+	top: -5px;
 }
 
 .box-shadow {
@@ -114,21 +132,6 @@ html, body {
 	height: 64px;
 	float: left;
 	position: absolute;
-}
-
-#tooltip span {
-	overflow: hidden;
-}
-
-#tooltiptext {
-	border-radius: 5px;
-	text-shadow: 2px 2px #000;
-	margin-bottom: 40px;
-	font-size: 12px;
-	margin-left: 10px;
-	color: #FFF;
-	position: relative;
-	top: -5px;
 }
 
 #bingo-box {

--- a/bingo.css
+++ b/bingo.css
@@ -90,13 +90,13 @@ html, body {
 	margin: 20px;
 	display: inline-block;
 	border: 2px solid purple;
+	border-radius: 5px;
 	background-color: rgba(0,0,0,.9);
 	font-family: settingsFont;
 	text-align: center;
 }
 
 .tooltiptext {
-	border-radius: 5px;
 	text-shadow: 2px 2px #000;
 	font-size: 12px;
 	color: #FFF;

--- a/bingo.css
+++ b/bingo.css
@@ -70,6 +70,11 @@ html, body {
 	text-align: center;
 }
 
+#copiedTooltip {
+	margin: 0 10px;
+	padding: 0 5px 5px;
+}
+
 .stream-exit-text {
 	color: #000;
 	text-align:center;

--- a/bingo.js
+++ b/bingo.js
@@ -69,8 +69,8 @@ $(document).ready(function()
 	// Set the background to a random image
 	document.body.style.backgroundImage = "url('Backgrounds/background" + (Math.floor(Math.random() * 10) + 1) + ".jpg')";
 
-	// By default hide the tooltip
-	$("#tooltip").hide();
+	// By default hide the tooltips
+	$(".tooltip").hide();
 
 	$("#export").hide();
 
@@ -88,14 +88,15 @@ $(document).ready(function()
 		return false;
 	});
 
+	const goalTooltip = $("#goalTooltip");
 	// On hovering a goal square
 	$("#bingo td img").hover(function()
 	{
-		$("#tooltip").show();
+		goalTooltip.show();
 	},function()
 	{
 		// After hovering, hide the tooltip again
-		$("#tooltip").hide();
+		goalTooltip.hide();
 	});
 
 	// Move the tooltip with the mouse
@@ -103,8 +104,8 @@ $(document).ready(function()
 	{
 		var x = e.pageX + 2;
 		var y = e.pageY + 2;
-		var width = $("#tooltip").outerWidth() + 25;
-		var height = $("#tooltip").height() + 50;
+		var width = goalTooltip.outerWidth() + 25;
+		var height = goalTooltip.height() + 50;
 		var maxX = $(window).width() + window.pageXOffset;
 		var maxY = $(window).height() + window.pageYOffset;
 		if (x + width > maxX) {
@@ -113,13 +114,13 @@ $(document).ready(function()
 		if (y + height > maxY) {
 			y = y - height;
 		}
-		$("#tooltip").css({left:x, top:y});
+		goalTooltip.css({left:x, top:y});
 	});
 
 	bingoSquares.hover(function(e)
 	{
 		hoveredSquare = $(this);
-		// Fill the #tooltip with the content from the goal
+		// Fill the #goalTooltip with the content from the goal
 		var tooltipImg = hoveredSquare.attr(TOOLTIP_IMAGE_ATTR_NAME);
 		var tooltipText = hoveredSquare.attr(TOOLTIP_TEXT_ATTR_NAME);
 		$("#tooltipimg").attr('src', tooltipImg);

--- a/bingo.js
+++ b/bingo.js
@@ -543,12 +543,14 @@ function setSquareColor(square, colorClass)
 	square.addClass(colorClass);
 }
 
-function copySeedToClipboard(id)
+function copySeedToClipboard(id, event)
 {
 	var id = "#"+id;
 	if (navigator.clipboard)
 	{
-		navigator.clipboard.writeText($(id).val()).catch(err => {
+		navigator.clipboard.writeText($(id).val()).then(ignored => {
+			showCopiedTooltip(event);
+		}, err => {
     			console.error('Async: Could not copy text: ', err);
     			alert("Failed to copy seed to clipboard :/");
 		});
@@ -564,6 +566,10 @@ function copySeedToClipboard(id)
 			{
 				alert("Failed to copy seed to clipboard :/");
 			}
+			else
+			{
+				showCopiedTooltip(event);
+			}
 		}
 		catch (err)
 		{
@@ -573,6 +579,18 @@ function copySeedToClipboard(id)
 		// Deselect
 		$(id).blur();
 	}
+}
+
+function showCopiedTooltip(event)
+{
+	const x = event.target.offsetLeft + event.target.offsetWidth;
+	const y = event.target.offsetTop;
+	$("#copiedTooltip").css({left:x, top: y})
+		.css("display", "block")
+		.delay(100)
+		.fadeOut(1000, () => {
+			$(this).hide().fadeIn(0);
+		});
 }
 
 function createGoalExport()

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 						<div id="hidden-table-seed">
 							Bingo Seed:<br>
 							<input class="seed_for_copying" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
-							<button class="button" onclick='copySeedToClipboard("seed_for_copying_hidden");'>Copy Seed</button>
+							<button class="button" onclick='copySeedToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
 						</div>
 						<p>Use this seed to create a new world in Minecraft. Remember to adjust ingame settings such as difficulty if necessary.</p>
 						<p>If you've been linked this page for a race, you are not allowed to change the seed/goals. See the full rules below.</p>
@@ -140,7 +140,7 @@
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (0-6)!</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
 			<h3>Creating the World</h3>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" onclick='copySeedToClipboard("seed_for_copying_howto");'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
 
@@ -157,6 +157,7 @@
 			<img src="" id="tooltipimg" />
 			<span id="tooltiptext" class="tooltiptext"></span>
 		</div>
+		<div id="copiedTooltip" class="tooltip"><span class="tooltiptext">Copied!</span></div>
 		<div id="export">
 			<p>The goals of the current sheet as JSON:</p>
 			<textarea readonly="readonly"></textarea>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 						<div id="hidden-table-seed">
 							Bingo Seed:<br>
 							<input class="seed_for_copying" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
-							<button onclick='copySeedToClipboard("seed_for_copying_hidden");'>Copy Seed to Clipboard</button>
+							<button class="button" onclick='copySeedToClipboard("seed_for_copying_hidden");'>Copy Seed</button>
 						</div>
 						<p>Use this seed to create a new world in Minecraft. Remember to adjust ingame settings such as difficulty if necessary.</p>
 						<p>If you've been linked this page for a race, you are not allowed to change the seed/goals. See the full rules below.</p>
@@ -140,7 +140,7 @@
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (0-6)!</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
 			<h3>Creating the World</h3>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button onclick='copySeedToClipboard("seed_for_copying_howto");'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" onclick='copySeedToClipboard("seed_for_copying_howto");'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
 

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 						<div id="hidden-table-seed">
 							Bingo Seed:<br>
 							<input class="seed_for_copying" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
-							<button class="button" onclick='copySeedToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
+							<button class="button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
 						</div>
 						<p>Use this seed to create a new world in Minecraft. Remember to adjust ingame settings such as difficulty if necessary.</p>
 						<p>If you've been linked this page for a race, you are not allowed to change the seed/goals. See the full rules below.</p>
@@ -140,7 +140,7 @@
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (0-6)!</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
 			<h3>Creating the World</h3>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
 

--- a/index.html
+++ b/index.html
@@ -153,9 +153,9 @@
 			<p>You can <a href="javascript:createGoalExport()">export the current sheet as JSON</a> for use in other tools such as <a href="https://bingosync.com/">Bingosync.</a></p>
 			<a href="https://github.com/Joshimuz/mcbingo"><img src="github-img.png" width='200'></a>
 		</section>
-		<div id="tooltip">
+		<div id="goalTooltip" class="tooltip">
 			<img src="" id="tooltipimg" />
-			<span id="tooltiptext"></span>
+			<span id="tooltiptext" class="tooltiptext"></span>
 		</div>
 		<div id="export">
 			<p>The goals of the current sheet as JSON:</p>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 			<div class="buttons-row">
 				<div class="dropdown-holder">
 					<button class="button versions-button dropdown-button" id="versions-toggle-button" title="Change version of Bingo"><!-- text set by updateVersion() --></button>
-					<div id="versions-dropdown-main" class="dropdown versions-dropdown"><!-- filled in by fillVersionSelection() --></div>
+					<div id="versions-dropdown-main" class="dropdown"><!-- filled in by fillVersionSelection() --></div>
 				</div>
 				<button onclick='newSeed(true);event.preventDefault();' class="button new-seed-button">Generate New Seed</button>
 				<div class="dropdown-holder">


### PR DESCRIPTION
Commit ce80d9d fixes the `border-radius` for tooltips:

![tooltip-border-radius](https://user-images.githubusercontent.com/624072/111459474-01438100-871b-11eb-99f1-87e42b655cc2.png)


Commit 124dc57 makes the "Copy Seed" buttons look like other buttons in the UI.

Tooltips on clicking the buttons have been added in commit 0db4326:

![hidden-table-button-tooltip2](https://user-images.githubusercontent.com/624072/111459563-22a46d00-871b-11eb-9378-32fbeb87b5a2.png)
![rules-section-button-tooltip2](https://user-images.githubusercontent.com/624072/111459569-246e3080-871b-11eb-95bb-0d3e2c0f084f.png)


Tooltips on hover have been added in commit 25ee363:
![hidden-table-button-title](https://user-images.githubusercontent.com/624072/111454655-2b924000-8715-11eb-8a1e-356092475962.png)
![rules-section-button-title](https://user-images.githubusercontent.com/624072/111454697-3a78f280-8715-11eb-853b-ef50a1c519a6.png)

The other commits are refactoring.