### PR TITLE
Version of jQuery has been upgraded to 3.6.0

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -408,7 +408,7 @@ function toggleHidden()
 }
 
 function popoutBingoCard(){
-    window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=745, height=705");
+	window.open(window.location.href, "_blank", "toolbar=no, status=no, menubar=no, scrollbars=no, width=745, height=705");
 }
 
 function toggleStreamerMode()
@@ -581,8 +581,8 @@ function copySeedToClipboard(id, event)
 		navigator.clipboard.writeText($(id).val()).then(ignored => {
 			showCopiedTooltip(event);
 		}, err => {
-    			console.error('Async: Could not copy text: ', err);
-    			alert("Failed to copy seed to clipboard :/");
+			console.error('Async: Could not copy text: ', err);
+			alert("Failed to copy seed to clipboard :/");
 		});
 	}
 	else

--- a/bingo.js
+++ b/bingo.js
@@ -547,7 +547,7 @@ function changeVersion(versionId)
 
 function fillVersionSelection()
 {
-	$.each(VERSIONS, function(index, value) {
+	VERSIONS.forEach(function(value) {
 		var label = value.name;
 		if (value.stable)
 		{

--- a/generator_v1.js
+++ b/generator_v1.js
@@ -136,7 +136,6 @@ var generator_v1 = function(layout, difficulty, bingoList)
 					}
 				}
 			}
- 			
 		}
 		while (!cont);
 

--- a/generator_v2.js
+++ b/generator_v2.js
@@ -158,7 +158,7 @@ var generator_v2 = function(layout, difficulty, bingoList)
 					}
 				}
 			}
- 			
+
 			// If the loop is stuck because no more suitable goals
 			if (failSafe >= 500)
 			{

--- a/generator_v3.js
+++ b/generator_v3.js
@@ -254,9 +254,9 @@ var generator_v3 = function(layout, difficulty, bingoList)
 }
 
 function shuffle(a) {
-    for (let i = a.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [a[i], a[j]] = [a[j], a[i]];
-    }
-    return a;
+	for (let i = a.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[a[i], a[j]] = [a[j], a[i]];
+	}
+	return a;
 }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<meta name="description" content="A Bingo sheet generator for Minecraft">
 		<link rel="stylesheet" href="bingo.css" type="text/css" />
 		
-		<script src="https://code.jquery.com/jquery-1.11.1.js"></script>
+		<script src="https://code.jquery.com/jquery-3.6.0.js"></script>
 		
 		<script src="generator_v1.js"></script>
 		<script src="generator_v2.js"></script>


### PR DESCRIPTION
Main change of the pull request is in commit c3a4318.

----

- I have tested every invocation of jQuery's `$` function in Firefox 86 and Chromium 89.
- I checked every release in [deprecation notes](https://api.jquery.com/category/deprecated/) – mcbingo doesn't use any deprecated functions. 
- I skimmed through [jQuery upgrade guides](https://jquery.com/upgrade-guide/). The only thing relevant to mcbingo was [a recommendation about `.show()` function](https://jquery.com/upgrade-guide/3.0/#breaking-change-show-hide-and-toggle-methods-now-respect-more-stylesheet-changes):
  > Further, while `.show()` and similar calls will continue to force visibility of elements that are hidden by stylesheet rules, supporting this functionality slows down all show/hide operations and its use is not recommended. The determination of which display value to set in such cases has also been simplified, defaulting to "block" when body-level rules hide elements by type.
  
  This doesn't matter much for mcbingo, because there is not a lot of elements hidden by stylesheet rules:
  
      $ git grep -c 'display *: *none' *.css
      bingo.css:6