### PR TITLE
Remove Pacifist reactant and RareBiome tag from Rabbit Stew

### DIFF
--- a/goals_v4.js
+++ b/goals_v4.js
@@ -285,7 +285,7 @@ var bingoList_v4 = [
 	{name: "(2-3) Magma Cream", tags: [Item, Nether, Combat]},
 	{name: "Create an Iron Golem", tags: [Action, Overworld]},
 	{name: "Eye of Ender", reactant: ["Pacifist"], antisynergy: ["EyeOfEnder"], tags: [Item, Nether, Combat]},
-	{name: "Rabbit Stew", reactant: ["Pacifist"], tags: [Item, RareBiome, Overworld]},
+	{name: "Rabbit Stew", tags: [Item, Overworld]},
 	{name: "Potion of Fire Resistance", infrequency: 12, tags: [Item, Nether, Combat]},
 	{name: "Potion of Healing", infrequency: 12, tags: [Item, Nether, Overworld]},
 	{name: "Potion of Poison", infrequency: 12, tags: [Item, Nether, Overworld]},


### PR DESCRIPTION
You can obtain a Rabbit Stew from the first Butcher trade.