### PR TITLE
CSS tweaks & cleanup

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -57,29 +57,6 @@ html, body {
 /* End Nav Bar */
 
 /* Bingo Card */
-
-#info_bar {
-	padding: 0;
-	margin-top: 10px;
-	text-align:center;
-}
-
-.seed_for_copying {
-	font-size: 1.01em;
-	text-align: center;
-}
-
-#copiedTooltip {
-	margin: 0 10px;
-	padding: 0 5px 5px;
-}
-
-.stream-exit-text {
-	color: #000;
-	text-align:center;
-	display:none;
-}
-
 #bingo-section {
 	width: 700px;
 	padding: 10px;
@@ -87,45 +64,6 @@ html, body {
 	margin-right: auto;
 	background-color: #EBEBEB;
 	border: 4px solid;
-}
-
-.tooltip {
-	position: absolute;
-	margin: 20px;
-	display: inline-block;
-	border: 2px solid purple;
-	border-radius: 5px;
-	background-color: rgba(0,0,0,.9);
-	text-align: center;
-}
-
-.tooltiptext {
-	text-shadow: 2px 2px #000;
-	font-size: 12px;
-	color: #FFF;
-	overflow: hidden;
-}
-
-#goalTooltip {
-	padding: 10px;
-	width: 300px;
-}
-
-#goalTooltip img {
-	border: 2px solid #EBEBEB;
-	margin-right: 5px;
-	width: 64px;
-	height: 64px;
-	float: left;
-	background-color: #C6C6C6;
-}
-
-#goalTooltip .tooltiptext {
-	line-height: 1.2em;
-	margin-bottom: 40px;
-	margin-left: 10px;
-	position: relative;
-	top: -5px;
 }
 
 #bingo-box {
@@ -153,21 +91,6 @@ html, body {
 	user-select: none;
 }
 
-#hidden-bingo {
-	display: none;
-	background-image: url("stone-tile.png");
-	background-repeat: repeat;
-	background-size: 128px 128px;
-	box-sizing: border-box;
-	padding: 50px;
-}
-.hidden #hidden-bingo {
-	display: block;
-}
-.hidden #bingo {
-	display: none;
-}
-
 #bingo td {
 	cursor: pointer;
 	width: 100px;
@@ -182,7 +105,7 @@ html, body {
 	position: relative;
 }
 
-/* Card colours */
+/** Card colours **/
 
 .symbol {
 	position: absolute;
@@ -265,7 +188,76 @@ html, body {
 	background-image: url("Symbols/apple.png");
 }
 
-/* End Card colours */
+/** Goal tooltip **/
+.tooltip {
+	position: absolute;
+	margin: 20px;
+	display: inline-block;
+	border: 2px solid purple;
+	border-radius: 5px;
+	background-color: rgba(0,0,0,.9);
+	text-align: center;
+}
+
+.tooltipQ {
+	opacity: 0.6;
+	width: 15px;
+	height: 15px;
+	position: absolute;
+	padding-top: 4px;
+	right: 5px;
+	top: 5px;
+}
+
+#bingo td[data-tooltiptext=""] .tooltipQ {
+	display: none;
+}
+
+.tooltiptext {
+	text-shadow: 2px 2px #000;
+	font-size: 12px;
+	color: #FFF;
+	overflow: hidden;
+}
+
+#goalTooltip {
+	padding: 10px;
+	width: 300px;
+}
+
+#goalTooltip img {
+	border: 2px solid #EBEBEB;
+	margin-right: 5px;
+	width: 64px;
+	height: 64px;
+	float: left;
+	background-color: #C6C6C6;
+}
+
+#goalTooltip .tooltiptext {
+	line-height: 1.2em;
+	margin-bottom: 40px;
+	margin-left: 10px;
+	position: relative;
+	top: -5px;
+}
+
+/** Hide Table mode **/
+#hidden-bingo {
+	display: none;
+	background-image: url("stone-tile.png");
+	background-repeat: repeat;
+	background-size: 128px 128px;
+	box-sizing: border-box;
+	padding: 50px;
+}
+
+.hidden #hidden-bingo {
+	display: block;
+}
+.hidden #bingo {
+	display: none;
+}
 
 #hidden-table {
 	background-color: white;
@@ -290,6 +282,11 @@ html, body {
 	text-align: center;
 }
 
+#copiedTooltip {
+	margin: 0 10px;
+	padding: 0 5px 5px;
+}
+
 #hidden-table-seed button {
 	margin-top: 10px;
 	width: 200px;
@@ -300,18 +297,16 @@ html, body {
 	margin: 20px auto 20px auto;
 }
 
-.tooltipQ {
-	opacity: 0.6;
-	width: 15px;
-	height: 15px;
-	position: absolute;
-	padding-top: 4px;
-	right: 5px;
-	top: 5px;
+/** Info bar **/
+#info_bar {
+	padding: 0;
+	margin-top: 10px;
+	text-align:center;
 }
 
-#bingo td[data-tooltiptext=""] .tooltipQ {
-	display: none;
+.seed_for_copying {
+	font-size: 1.01em;
+	text-align: center;
 }
 
 /* End Bingo Card  */
@@ -492,6 +487,13 @@ input[type=range]::-ms-thumb:active {
 /* End UI controls */
 
 /* Streamer Mode */
+
+.stream-exit-text {
+	color: #000;
+	text-align:center;
+	display:none;
+}
+
 .streamer-mode #nav_section,
 .streamer-mode .buttons-row,
 .streamer-mode #rules-section {

--- a/bingo.css
+++ b/bingo.css
@@ -482,7 +482,6 @@ input[type=range]::-ms-thumb:active {
 
 .new-seed-button {
 	width: 382px;
-	text-decoration: none;
 }
 
 /* End Buttons */

--- a/bingo.css
+++ b/bingo.css
@@ -317,8 +317,9 @@ html, body {
 
 /* End Bingo Card  */
 
-/* Buttons */
+/* UI controls */
 
+/** Buttons **/
 .buttons-row {
 	margin-top: 10px;
 	display: flex;
@@ -333,6 +334,34 @@ html, body {
 	background-image: url("button-background.png");
 }
 
+.button,
+.slider-holder,
+.slider {
+	cursor: pointer;
+	height: 50px;
+}
+.button,
+.slider-text {
+	color: #FFF;
+	font-size: 20px;
+	text-align: center;
+	text-shadow: 0.125em 0.125em #3f3f3f;
+}
+.small-button {
+	padding: 2px 6px 3px;
+	height: auto;
+	font-size: 1em;
+}
+
+.button:hover,
+.slider-holder:hover .slider-text {
+	color: #FFF787;
+}
+.button:hover {
+	background-image: url("button-background-blue.png");
+}
+
+/*** Button border and insets ***/
 .button::after,
 .button::before {
 	content: '';
@@ -355,50 +384,11 @@ html, body {
 	border-right: unset;
 }
 
-.button:hover,
-.slider-holder:hover .slider-text {
-	color: #FFF787;
-}
-.button:hover {
-	background-image: url("button-background-blue.png");
-}
-
-.button,
-.slider-holder,
-.slider {
-	cursor: pointer;
-	height: 50px;
-}
-.button,
-.slider-text {
-	color: #FFF;
-	font-size: 20px;
-	text-align: center;
-	text-shadow: 0.125em 0.125em #3f3f3f;
-}
-.small-button {
-	padding: 2px 6px 3px;
-	height: auto;
-	font-size: 1em;
-}
-
-.versions-button {
-	width: 50px;
-}
-.version-button {
-	width: 300px;
-}
-
-.options-button,
-.slider-holder,
-.slider,
-.slider-text {
-	width: 250px;
-}
-
+/** Dropdowns **/
 .dropdown-holder  {
 	position: relative;
 }
+
 .dropdown {
 	display: none;
 	position: absolute;
@@ -407,6 +397,7 @@ html, body {
 	z-index: 1;
 }
 
+/** Sliders **/
 .slider-holder {
 	background-image: url("slider-background.png");
 	position: relative;
@@ -475,11 +466,26 @@ input[type=range]::-ms-thumb:active {
 	background-image: url("button-background-blue.png");
 }
 
+/** Individual controls' sizes **/
+.versions-button {
+	width: 50px;
+}
+.version-button {
+	width: 300px;
+}
+
 .new-seed-button {
 	width: 382px;
 }
 
-/* End Buttons */
+.options-button,
+.slider-holder,
+.slider,
+.slider-text {
+	width: 250px;
+}
+
+/* End UI controls */
 
 /* Streamer Mode */
 .streamer-mode #nav_section,

--- a/bingo.css
+++ b/bingo.css
@@ -489,9 +489,9 @@ input[type=range]::-ms-thumb:active {
 /* Streamer Mode */
 
 .stream-exit-text {
-	color: #000;
-	text-align:center;
-	display:none;
+	color: #505050;
+	text-align: center;
+	display: none;
 }
 
 .streamer-mode #nav_section,

--- a/bingo.css
+++ b/bingo.css
@@ -338,6 +338,9 @@ html, body {
 .slider-holder,
 .slider {
 	cursor: pointer;
+}
+.button,
+.slider-holder {
 	height: 50px;
 }
 .button,
@@ -404,8 +407,12 @@ html, body {
 	-webkit-appearance: none;
 }
 
+.slider,
+.slider-text {
+	width: 100%;
+	height: 100%;
+}
 .slider {
-	width: 250px;
 	position: relative;
 	z-index: 100;
 	background-color: transparent;
@@ -479,9 +486,7 @@ input[type=range]::-ms-thumb:active {
 }
 
 .options-button,
-.slider-holder,
-.slider,
-.slider-text {
+.slider-holder {
 	width: 250px;
 }
 

--- a/bingo.css
+++ b/bingo.css
@@ -130,15 +130,6 @@ html, body {
 	top: -5px;
 }
 
-.box-shadow {
-	box-shadow: inset 3px 3px 3px 0px rgba(0,0,0,0.75);
-	border: 2px solid white;
-	width: 64px;
-	height: 64px;
-	float: left;
-	position: absolute;
-}
-
 #bingo-box {
 	width: 700px;
 	height: 600px;

--- a/bingo.css
+++ b/bingo.css
@@ -564,6 +564,7 @@ body.streamer-mode {
 
 #export textarea {
 	flex-grow: 1;
+	font-family: monospace;
 }
 
 /* End Export Popup */

--- a/bingo.css
+++ b/bingo.css
@@ -25,7 +25,7 @@ html, body {
 
 /* End Base Page */
 
-/* Nav Bar Styling */
+/* Nav Bar */
 
 #nav_section {
 	background-color: #F6F6F6;
@@ -55,7 +55,7 @@ html, body {
 
 /* End Nav Bar */
 
-/* Bingo Card Styling */
+/* Bingo Card */
 
 #info_bar {
 	padding: 0;
@@ -330,7 +330,7 @@ html, body {
 
 /* End Bingo Card  */
 
-/* Buttons Styling */
+/* Buttons */
 
 .buttons-row {
 	margin-top: 10px;
@@ -494,9 +494,9 @@ input[type=range]::-ms-thumb:active {
 	text-decoration: none;
 }
 
-/* End Buttons Styling */
+/* End Buttons */
 
-/* Streamer Mode Styling */
+/* Streamer Mode */
 .streamer-mode #nav_section,
 .streamer-mode .buttons-row,
 .streamer-mode #rules-section {
@@ -510,9 +510,9 @@ input[type=range]::-ms-thumb:active {
 body.streamer-mode {
 	background-size: 0, 0;
 }
-/* End Streamer Mode Styling */
+/* End Streamer Mode */
 
-/* Rules And Bottom Styling */
+/* Rules And Bottom */
 
 #rules-section {
 	margin-top: 10px;

--- a/bingo.css
+++ b/bingo.css
@@ -296,7 +296,6 @@ html, body {
 }
 
 .show-table-button {
-	background-size: 500px 50px;
 	width: 450px;
 	margin: 20px auto 20px auto;
 }

--- a/bingo.css
+++ b/bingo.css
@@ -2,6 +2,7 @@
 * {
 	margin: 0;
 	padding: 0;
+	font-family: Minecraftia;
 }
 
 button:focus, input:focus {
@@ -14,7 +15,7 @@ button:focus, input:focus {
 }
 
 @font-face {
-	font-family: settingsFont;
+	font-family: Minecraftia;
 	src: url(Minecraftia.ttf);
 }
 
@@ -60,12 +61,10 @@ html, body {
 #info_bar {
 	padding: 0;
 	margin-top: 10px;
-	font-family: settingsFont;
 	text-align:center;
 }
 
 .seed_for_copying {
-	font-family: settingsFont;
 	font-size: 1.01em;
 	text-align: center;
 }
@@ -97,7 +96,6 @@ html, body {
 	border: 2px solid purple;
 	border-radius: 5px;
 	background-color: rgba(0,0,0,.9);
-	font-family: settingsFont;
 	text-align: center;
 }
 
@@ -177,7 +175,6 @@ html, body {
 	text-align:center;
 	font-size: .75em;
 	background-color: #C6C6C6;
-	font-family: settingsFont;
 	border: 2px solid #EBEBEB;
 	box-shadow: inset 3px 3px 3px 0px rgba(0,0,0,0.75);
 	color: #000;
@@ -271,7 +268,6 @@ html, body {
 /* End Card colours */
 
 #hidden-table {
-	font-family: settingsFont;
 	background-color: white;
 	color: #000;
 	border: 2px solid #000;
@@ -377,7 +373,6 @@ html, body {
 .slider-text {
 	color: #FFF;
 	font-size: 20px;
-	font-family: settingsFont;
 	text-align: center;
 	text-shadow: 0.125em 0.125em #3f3f3f;
 }
@@ -509,7 +504,6 @@ body.streamer-mode {
 	background-color: #FFF;
 	padding: 10px 0px 10px 0px;
 	border-top: 5px solid;
-	font-family: settingsFont;
 	font-size:0.75em;
 	text-align: center;
 }


### PR DESCRIPTION
- File `bingo.css` has been reorganised. Commits, which reorder the rules, are best viewed using [`--color-moved` option of `git show`](https://git-scm.com/docs/git-show#Documentation/git-show.txt---color-movedltmodegt).
- CSS rules for sliders have been refactored – this is in preparation for #106.
- Background texture for "Show Table" button has been fixed:
![show-table-button-tweak](https://user-images.githubusercontent.com/624072/112249569-52da9700-8c58-11eb-8ec1-b3e726ae7831.png)
- Font Minecraftia has been applied to more elements:
    1. Version select:
![font-change-version-select](https://user-images.githubusercontent.com/624072/112249642-6ede3880-8c58-11eb-8a19-88eb24783b42.png)
    2. Streamer mode links (with lighter colour than before): 
![font-change-streamer-mode-exit](https://user-images.githubusercontent.com/624072/112249702-80bfdb80-8c58-11eb-8357-0297e2f81f9a.png)
    3. Header and "Hide" link in export dialog:
![font-change-export](https://user-images.githubusercontent.com/624072/112249734-8d443400-8c58-11eb-9590-e1e6854248b4.png)


