### PR TITLE
Calculation of the position for the "Copied!" tooltip has been fixed

### DIFF
--- a/bingo.js
+++ b/bingo.js
@@ -650,8 +650,9 @@ function copySeedToClipboard(id, event)
 
 function showCopiedTooltip(event)
 {
-	const x = event.target.offsetLeft + event.target.offsetWidth;
-	const y = event.target.offsetTop;
+	const offset = $(event.target).offset();
+	const x = offset.left + event.target.offsetWidth;
+	const y = offset.top;
 	$("#copiedTooltip").css({left:x, top: y})
 		.css("display", "block")
 		.delay(100)


### PR DESCRIPTION
A fix for a bug introduced in #113.

Before:

https://user-images.githubusercontent.com/624072/112728161-252a7200-8f26-11eb-954b-98bf53a368b1.mp4

After:

![after](https://user-images.githubusercontent.com/624072/112728165-29ef2600-8f26-11eb-898d-d39cdd537f7a.png)


