### PR TITLE
Save load progress simple. Closes #102

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -380,12 +380,21 @@ html, body {
 	border-bottom-width: 4px;
 	border-top: unset;
 	border-left: unset;
+	transition: background ease-in-out 0.3s;
 }
 
 .button::before {
 	border: 3px solid #ffffff6e;
 	border-bottom: unset;
 	border-right: unset;
+}
+
+.button.success--ok::after {
+	background-size: contain;
+	background-image: url("Symbols/ok.png");
+	background-color: #abff3c75;
+  background-repeat: no-repeat;
+	background-position: center;
 }
 
 /** Dropdowns **/
@@ -673,7 +682,7 @@ body.streamer-mode {
 	
 	max-width: 680px;
 	transform: translate(-50%, 0);
-  z-index: 1000;
+	z-index: 1000;
 }
 
 .popup .popup-button-group {
@@ -712,7 +721,7 @@ body.streamer-mode {
 	top: 50%;
 	max-width: 600px;
 	padding: 20px;
-  transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
 }
 #urlWithProgress #url_with_current_progress,
 #urlWithProgress .popup-button-group {

--- a/bingo.css
+++ b/bingo.css
@@ -286,6 +286,11 @@ html, body {
 #copiedTooltip {
 	margin: 0 10px;
 	padding: 0 5px 5px;
+	z-index: 1001;
+}
+
+#copiedTooltip.fixed {
+	position: fixed;
 }
 
 #hidden-table-seed button {
@@ -584,7 +589,32 @@ body.streamer-mode {
 	filter: blur(0.1em);
 }
 .hidden.show-options #hidden-bingo {
-	filter: blur(0.5em);
+	filter: blur(0.4em);
+}
+
+.show-options,
+.show-options #options-menu,
+.show-options #bingo,
+.show-options #hidden-bingo,
+.show-options.show-popup {
+	transition: filter ease-in-out 0.3s;
+}
+.show-options #bingo,
+.show-options #hidden-bingo {
+	transition-duration: 0.15s;
+}
+
+.show-options.show-popup {
+	filter: brightness(0.9);
+}
+
+.show-options.show-popup #bingo,
+.show-options.show-popup #options-menu {
+	pointer-events: none;
+	filter: blur(0.1em);
+}
+.show-options.show-popup #bingo {
+	filter: blur(0.2em);
 }
 
 .pause-menu-group {
@@ -597,6 +627,11 @@ body.streamer-mode {
 #options-menu .slider-holder,
 #options-menu .slider {
 	width: 16rem;
+}
+
+.options-button--space-holder {
+	pointer-events: none;
+	opacity: 0;
 }
 
 .version-button {
@@ -619,26 +654,70 @@ body.streamer-mode {
 
 /* End Pause Menu */
 
-/* Export Popup */
-
-#export {
-	width: 50%;
-	height: 50%;
+/* Popup */
+.popup {
 	position: fixed;
-	border: 4px solid #000;
 	top: 10%;
-	left: 25%;
-	background: white;
+	left: 50%;
+	width: 65%;
+	height: auto;
 	display: flex;
+	padding: 10px 20px;
 	flex-direction: column;
 	align-items: stretch;
 	text-align: center;
-	padding: 4px;
+	
+	background: white;
+	border: 4px solid #000;
+	box-shadow: #00000057 0 0 10px 10px;
+	
+	max-width: 680px;
+	transform: translate(-50%, 0);
+  z-index: 1000;
+}
+
+.popup .popup-button-group {
+	margin-top: 10px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-around;
+}
+
+.popup .popup-button-group .button {
+  padding: 0 15px;
+}
+
+@media (max-width: 460px) {
+	.popup .popup-button-group {
+		flex-direction: column;
+	}
+}
+/* End Popup */
+
+/* Per-Popup stype */
+
+#export {
+	min-height: 180px;
 }
 
 #export textarea {
 	flex-grow: 1;
 	font-family: monospace;
+	resize: vertical;
+	margin-top: 10px;
 }
 
-/* End Export Popup */
+#urlWithProgress {
+	position: absolute;
+	top: 50%;
+	max-width: 600px;
+	padding: 20px;
+  transform: translate(-50%, -50%);
+}
+#urlWithProgress #url_with_current_progress,
+#urlWithProgress .popup-button-group {
+	margin-top: 20px;
+}
+
+
+/* End Per-Popup style */

--- a/bingo.css
+++ b/bingo.css
@@ -670,7 +670,7 @@ body.streamer-mode {
 	left: 50%;
 	width: 65%;
 	height: auto;
-	display: flex;
+	display: none;
 	padding: 10px 20px;
 	flex-direction: column;
 	align-items: stretch;
@@ -683,6 +683,9 @@ body.streamer-mode {
 	max-width: 680px;
 	transform: translate(-50%, 0);
 	z-index: 1000;
+}
+.popup.opened {
+	display: flex;
 }
 
 .popup .popup-button-group {

--- a/bingo.js
+++ b/bingo.js
@@ -20,6 +20,7 @@ const NEVER_HIGHLIGHT_CLASS_NAME = "greensquare";
 const SHEET_PROGRESS_KEY = "bingoSheetProgress";
 const SHEET_PROGRESS_SAVE_LIMIT = 5;
 const URL_PARAM_PROGRESS = "progress";
+const WAS_SAVE_POPUP_OPEN_KEY = "wasAutosavePopupOpen";
 
 var hoveredSquare;
 
@@ -297,7 +298,7 @@ function getSettingsFromURLSplitted(url)
 
 function getSettingsFromURL()
 {
-  [SEED, DIFFICULTY, VERSION, HIDDEN, STREAMER_MODE] = getSettingsFromURLSplitted();
+	[SEED, DIFFICULTY, VERSION, HIDDEN, STREAMER_MODE] = getSettingsFromURLSplitted();
 
 	// If there isn't a seed, make a new one
 	if (!SEED)
@@ -552,7 +553,7 @@ function toggleColourSymbols(value)
 {
 	COLOURSYMBOLS = !COLOURSYMBOLS;
 	updateColourSymbols();
-	pushNewLocalSetting(COLOUR_SYMBOLS_SETTING_NAME, COLOURSYMBOLS);	
+	pushNewLocalSetting(COLOUR_SYMBOLS_SETTING_NAME, COLOURSYMBOLS);
 }
 
 function generateNewUrlParam()
@@ -769,7 +770,6 @@ function generateSquareProgress()
 {
 	var squares = []
 	forEachSquare((i, square) => {
-		console.log(square.attr('class') || '22');
 		squares.push(ALL_COLOURS.indexOf(square.attr('class') || ''));
 	});
 	return squares;
@@ -861,14 +861,21 @@ function createGoalExport()
 	openPopup("#export");
 }
 
-function showLinkWithProgress()
+function showLinkWithProgress(element)
 {
 	var urlWithProgress = generateNewUrlParamWithProgress(generateSquareProgress());
 	pushNewUrl(urlWithProgress);
-	$("#urlWithProgress #url_with_current_progress").val(window.location.origin + urlWithProgress);
-	$('.js-save-progress-limit').text(SHEET_PROGRESS_SAVE_LIMIT);
-	$('#bingo-box').addClass(SHOW_POPUP_MENU_CLASS_NAME);
-	openPopup("#urlWithProgress");
+	if (! localStorage.getItem(WAS_SAVE_POPUP_OPEN_KEY)) {
+		$('.js-save-progress-limit').text(SHEET_PROGRESS_SAVE_LIMIT);
+		$('#bingo-box').addClass(SHOW_POPUP_MENU_CLASS_NAME);
+		openPopup("#urlWithProgress");
+		pushNewLocalSetting(WAS_SAVE_POPUP_OPEN_KEY, true);
+	} else if(element !== undefined) {
+		$(element).addClass('success--ok');
+		setTimeout(function() {
+			$(element).removeClass('success--ok');
+		}, 1000);
+	}
 }
 
 function openPopup(popup)

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 						<div id="hidden-table-seed">
 							Bingo Seed:<br>
 							<input class="seed_for_copying" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
-							<button class="button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
+							<button class="button" title="Copy Seed to Clipboard" onclick='copyToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
 						</div>
 						<p>Use this seed to create a new world in Minecraft. Remember to adjust ingame settings such as difficulty if necessary.</p>
 						<p>If you've been linked this page for a race, you are not allowed to change the seed/goals. See the full rules below.</p>
@@ -165,7 +165,7 @@
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (1-6) to select a colour or (0/q) to remove the colour! Distinct symbols on the squares for each colour can be toggled in the Options menu.</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
 			<h3>Creating the World</h3>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copyToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
 
@@ -187,7 +187,7 @@
 			<p>The goals of the current sheet as JSON:</p>
 			<textarea readonly="readonly" id="goals_in_json"></textarea>
 			<div class="popup-button-group">
-				<button class="button" title="Copy JSON to Clipboard" onclick='copySeedToClipboard("goals_in_json", event, true);'>Copy JSON</button>
+				<button class="button" title="Copy JSON to Clipboard" onclick='copyToClipboard("goals_in_json", event, true);'>Copy JSON</button>
 				<button class="button" onclick="closePopupByButton(this);">Close</button>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 							<button class="button options-button options-button--space-holder"></button>
 						</div>
 						<div class="pause-menu-group">
-							<button class="button options-button" onclick="showLinkWithProgress();">Save progress</button>
+							<button class="button options-button" onclick="showLinkWithProgress(this);">Save progress</button>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -117,9 +117,15 @@
 						</div>
 					</div>
 					<div class="pause-menu-column">
-						<div class="dropdown-holder">
-							<button class="button options-button dropdown-button" id="versions-toggle-button" title="Change version of Bingo"><!-- text set by updateVersion() --></button>
-							<div id="versions-dropdown-main" class="dropdown"><!-- filled in by fillVersionSelection() --></div>
+						<div class="pause-menu-group">
+							<div class="dropdown-holder">
+								<button class="button options-button dropdown-button" id="versions-toggle-button" title="Change version of Bingo"><!-- text set by updateVersion() --></button>
+								<div id="versions-dropdown-main" class="dropdown"><!-- filled in by fillVersionSelection() --></div>
+							</div>
+							<button class="button options-button options-button--space-holder"></button>
+						</div>
+						<div class="pause-menu-group">
+							<button class="button options-button" onclick="showLinkWithProgress();">Save progress</button>
 						</div>
 					</div>
 				</div>
@@ -177,10 +183,23 @@
 			<span id="tooltiptext" class="tooltiptext"></span>
 		</div>
 		<div id="copiedTooltip" class="tooltip"><span class="tooltiptext">Copied!</span></div>
-		<div id="export">
+		<div id="export" class="popup">
 			<p>The goals of the current sheet as JSON:</p>
-			<textarea readonly="readonly"></textarea>
-			<a href="javascript:hideGoalExport()">Hide</a>
+			<textarea readonly="readonly" id="goals_in_json"></textarea>
+			<div class="popup-button-group">
+				<button class="button" title="Copy JSON to Clipboard" onclick='copySeedToClipboard("goals_in_json", event, true);'>Copy JSON</button>
+				<button class="button" onclick="closePopupByButton(this);">Close</button>
+			</div>
+		</div>
+		<div id="urlWithProgress" class="popup" data-keep-options-open="true">
+			<p>Your current progress of the bingo sheet is automatically saved into your browser and will be restored next time you open same link.</p>
+			<br>
+			<p>If you want to save current progress for longer or share with others, use following link:</p>
+			<input id="url_with_current_progress" readonly="readonly" value=""/>
+			<div class="popup-button-group">
+				<button class="button" title="Copy link to Clipboard" onclick='copySeedToClipboard("url_with_current_progress", event, true);'>Copy link</button>
+				<button class="button" onclick="closePopupByButton(this);">Close</button>
+			</div>
 		</div>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -192,12 +192,10 @@
 			</div>
 		</div>
 		<div id="urlWithProgress" class="popup" data-keep-options-open="true">
-			<p>Your current progress of the bingo sheet is automatically saved into your browser and will be restored next time you open same link.</p>
+			<p>Automatic saving of bingo progress to URL has been enabled. Now you can use current URL to restore your progress later or share it others.</p>
 			<br>
-			<p>If you want to save current progress for longer or share with others, use following link:</p>
-			<input id="url_with_current_progress" readonly="readonly" value=""/>
+			<small>Tip: You don't need to save progress every time using this button, your last <span class="js-save-progress-limit">0</span> bingo sheets are already automatically saved and will be restored next time you open the same link.</small>
 			<div class="popup-button-group">
-				<button class="button" title="Copy link to Clipboard" onclick='copySeedToClipboard("url_with_current_progress", event, true);'>Copy link</button>
 				<button class="button" onclick="closePopupByButton(this);">Close</button>
 			</div>
 		</div>


### PR DESCRIPTION
This PR contain changes for #102. Current progress (and last 5 bingo sheets with progress _[older saves will be overwritten]_) are automatically stored in `localStorage` and will be auto-restored (load) when url with same settings (`SEED`, `DIFFICULTY`, `VERSION`) is opened. Also added button to generate url with current progress to store progress indefinitely (to continue later or share with others). Progress in url will be autoupdated upon changes to the sheet.

Demo:

https://user-images.githubusercontent.com/16069758/114303719-3b186500-9ad8-11eb-9e94-9ba32d2b0c83.mov

