### PR TITLE
generator_v3: update top comment

### DIFF
--- a/generator_v3.js
+++ b/generator_v3.js
@@ -1,4 +1,4 @@
-// This is part of a version currently in development and may be changed at any time.
+// Used in stable v4 -- should be copied as generator_v4 to introduce goal generation changes in v5
 
 var generator_v3 = function(layout, difficulty, bingoList)
 {


### PR DESCRIPTION
Since commit b712eea (Version 4 preperations, 2021-03-22), `generator_v3`
has been used in version 4 of Minecraft Bingo.  Version 4 is marked as
stable, so goal generation done by `generator_v3` should not change.
Update the top comment in `generator_v3.js` to reflect that.