### PR TITLE
GitHub: add "Sponsor this project" links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://donate.joshimuz.com", "https://joshimuz.com/subscribe"]


### PR DESCRIPTION
Add two links to the landing page of the GitHub repository.  First link
is for donations, second link -- for Twitch subscription.  The links are
displayed in the "Sponsor this project" block in the sidebar on the
right.  GitHub documentation about the sponsor buttons:
https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository

----

It would look like this:
![image](https://user-images.githubusercontent.com/624072/142922684-d30f156a-f453-48f2-b030-da3ba89126ca.png)

You can see how it looks and works at https://github.com/rybak/mcbingo which at the moment has this commit merged into `master` branch.