### PR TITLE
bingo.js: Make readonly seed input below sheet editable

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -392,7 +392,7 @@ body {
 	color: var(--fg-colour);
 }
 
-.seed_for_copying {
+.seed-input {
 	font-size: 1.01em;
 	text-align: center;
 }

--- a/bingo.js
+++ b/bingo.js
@@ -498,7 +498,6 @@ function changeDifficulty(value)
 function changeSeed(value)
 {
 	SEED = value;
-	//updateDifficulty();
 	generateNewSheet();
 	pushNewUrl();
 }

--- a/bingo.js
+++ b/bingo.js
@@ -349,7 +349,7 @@ function generateNewSheet()
 {
 	let seedInput = $(".seed-input");
 	seedInput.val(SEED);
-	seedInput.attr("size", Math.max(SEED.length, 1));
+	seedInput.attr("size", Math.max(SEED.length, 5));
 
 	// Reset the random seed
 	Math.seedrandom(SEED);

--- a/bingo.js
+++ b/bingo.js
@@ -347,8 +347,9 @@ function forEachSquare(f)
 
 function generateNewSheet()
 {
-	$(".seed_for_copying").val(SEED);
-	$(".seed_for_copying").attr("size", SEED.length);
+	let seedInput = $(".seed-input");
+	seedInput.val(SEED);
+	seedInput.attr("size", Math.max(SEED.length, 1));
 
 	// Reset the random seed
 	Math.seedrandom(SEED);
@@ -490,6 +491,14 @@ function changeDifficulty(value)
 {
 	DIFFICULTY = parseInt(value);
 	updateDifficulty();
+	generateNewSheet();
+	pushNewUrl();
+}
+
+function changeSeed(value)
+{
+	SEED = value;
+	//updateDifficulty();
 	generateNewSheet();
 	pushNewUrl();
 }

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 					<div id="hidden-table">
 						<div id="hidden-table-seed">
 							Bingo Seed:<br>
-							<input class="seed_for_copying" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
+							<input class="seed-input" id="seed_for_copying_hidden" type="text" value="12345" readonly="readonly"><br>
 							<button class="button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_hidden", event);'>Copy Seed</button>
 						</div>
 						<p>Use this seed to create a new world in Minecraft. Remember to adjust ingame settings such as difficulty if necessary.</p>
@@ -126,7 +126,7 @@
 				</div>
 			</div>
 			<div id="info_bar">
-				Seed: <input class="seed_for_copying" type="text" value="12345" readonly="readonly" />&emsp;Difficulty: <span class="difficulty-text"></span>&emsp;Version: <span class="versionText"></span><br>
+				Seed: <input class="seed-input" type="text" value="12345" oninput="changeSeed(value)" />&emsp;Difficulty: <span class="difficulty-text"></span>&emsp;Version: <span class="versionText"></span><br>
 			</div>
 			<div class="buttons-row">
 				<button onclick='newSeed(true);event.preventDefault();' class="button new-seed-button">Generate New Seed</button>
@@ -160,7 +160,7 @@
 			<p><em>Tip:</em> You can click on the squares to change their colour which is useful for planning or to mark off completed goals. Use the colour slider in the Options menu to choose how many colours you want to use. You can also hover over the square and press (1-6) to select a colour or (0/q) to remove the colour! Distinct symbols on the squares for each colour can be toggled in the Options menu.</p>
 			<p><em>Tip:</em> Hover over a "?" to get more information about that goal.</p>
 			<h3>Creating the World</h3>
-			<p>Create a new world in Minecraft and use <input class="seed_for_copying" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
+			<p>Create a new world in Minecraft and use <input class="seed-input" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
 


### PR DESCRIPTION
This allows for the seed input located directly below the sheet to be editable, as it is inconvenient to do so while the sheet is popped out.