### PR TITLE
Various CSS fixes

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -765,7 +765,12 @@ select, input[type="text"] {
 
 /* Export Popup */
 
+.show-export #export {
+	display: flex;
+}
+
 #export {
+	display: none;
 	width: 50%;
 	height: 50%;
 	position: fixed;
@@ -774,7 +779,6 @@ select, input[type="text"] {
 	left: 25%;
 	color: var(--fg-colour);
 	background: var(--bg-colour);
-	display: flex;
 	flex-direction: column;
 	align-items: stretch;
 	text-align: center;

--- a/bingo.css
+++ b/bingo.css
@@ -77,6 +77,11 @@ body {
 	background-color: var(--bg-colour);
 	background-size: 1920px 1080px;
 }
+@media only screen and (min-width: 1921px) {
+	body {
+		background-size: contain;
+	}
+}
 body {
 	min-height: 100%;
 }

--- a/bingo.css
+++ b/bingo.css
@@ -279,7 +279,7 @@ body {
 .tooltip {
 	position: absolute;
 	margin: 20px;
-	display: inline-block;
+	display: none;
 	border: 2px solid purple;
 	border-radius: 5px;
 	background-color: rgba(0,0,0,.9);

--- a/bingo.css
+++ b/bingo.css
@@ -788,6 +788,7 @@ select, input[type="text"] {
 	align-items: stretch;
 	text-align: center;
 	padding: 4px;
+	z-index: 200;
 }
 
 #export textarea {

--- a/bingo.js
+++ b/bingo.js
@@ -90,9 +90,6 @@ $(document).ready(function()
 	// Set the background to a random image
 	document.body.className += "bg" + (Math.floor(Math.random() * 10) + 1);
 
-	// By default hide the tooltips
-	$(".tooltip").hide();
-
 	// On clicking a goal square
 	const bingoSquares = $("#bingo td");
 	bingoSquares.click(function()

--- a/bingo.js
+++ b/bingo.js
@@ -57,6 +57,7 @@ const COLOUR_THEME_SETTING_NAME = "bingoColourTheme";
 const DARK_MODE_CLASS_NAME = "dark";
 
 const SHOW_OPTIONS_MENU_CLASS_NAME = "show-options";
+const SHOW_EXPORT_CLASS_NAME = "show-export";
 
 // Dropdowns and pause menu handling.
 $(document).click(function(event) {
@@ -91,8 +92,6 @@ $(document).ready(function()
 
 	// By default hide the tooltips
 	$(".tooltip").hide();
-
-	$("#export").hide();
 
 	// On clicking a goal square
 	const bingoSquares = $("#bingo td");
@@ -708,12 +707,12 @@ function createGoalExport()
 		});
 	});
 	$("#export textarea").text(JSON.stringify(result));
-	$("#export").show();
+	$("body").addClass(SHOW_EXPORT_CLASS_NAME);
 }
 
 function hideGoalExport()
 {
-	$("#export").hide();
+	$("body").removeClass(SHOW_EXPORT_CLASS_NAME);
 }
 
 // Made this a function for readability and ease of use


### PR DESCRIPTION
Several fixes for minor glitches.

----

First commit fixes a glitch, where the export popup flashes for a split second during page load. This is how the glitch looks like without the fix:

[demo of export popup flash glitch ](https://user-images.githubusercontent.com/624072/221416292-0463982f-fcd0-43fc-9933-e10700be3a97.webm)

----

Second commit simplifies JS by moving tooltip hiding to CSS. It's not visible during regular use, but here's how tooltips look at the bottom of the site with disabled JavaScript, just for fun:

![tooltip glitch](https://user-images.githubusercontent.com/624072/221413069-84361bd4-afca-4c55-9a61-cb3c7a266edc.png "tooltip glitch, that is not visible usually")

----

Third commit fixes backgrounds on monitors wider than 1920p:

![before and after of background image glitch](https://user-images.githubusercontent.com/624072/221415656-36fe8288-9abe-403a-b970-6928ff59cf28.png "before and after of background image glitch")

----

Fourth commit fixes z-index glitch between export popup and options menu and sliders. It's easy to get the slider glitch in regular use – just scroll all the way up while export is showing:

![before and after of z-index glitch for slider](https://user-images.githubusercontent.com/624072/221415959-2788524c-169c-4c7a-919f-e662d35143d7.png "before and after of z-index glitch for slider")

But a bit harder to see options menu over the export – it requires clicking the "Options" button while export is showing or pressing the <kbd>Esc</kbd> key:
![before and after of z-index glitch for options menu](https://user-images.githubusercontent.com/624072/221416018-41633c1c-7e9d-48d1-a7d3-ed21f045dd96.png "before and after of z-index glitch for options menu")