### PR TITLE
goals_v5: add Overworld tag to potions

### DIFF
--- a/goals_v4.js
+++ b/goals_v4.js
@@ -1,4 +1,5 @@
-// This is part of a version currently in development and may be changed at any time.
+// This file should not be edited anymore since a stable version refers to it (except
+// maybe for purely visual things that don't change the goals, like typos).
 
 // Tags
 var Item = {name: "Item", max: [25, 25, 20, 20, 20], line: true},

--- a/goals_v5.js
+++ b/goals_v5.js
@@ -288,13 +288,13 @@ var bingoList_v5 = [
 	{name: "Create an Iron Golem", tags: [Action, Overworld]},
 	{name: "Eye of Ender", reactant: ["Pacifist"], antisynergy: ["EyeOfEnder"], tags: [Item, Nether, Combat]},
 	{name: "Rabbit Stew", tags: [Item, Overworld]},
-	{name: "Potion of Fire Resistance", infrequency: 12, tags: [Item, Nether]}, // no Pacifist reactant and no Combat tag, because can be bartered
+	{name: "Potion of Fire Resistance", infrequency: 12, tags: [Item, Nether]}, // no Pacifist reactant and no Combat tag (Blaze Powder), no Overworld tag (Water Bottles), because can be bartered
 	{name: "Potion of Healing", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Poison", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Harming", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
-	{name: "Potion of Regeneration", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Combat]},
+	{name: "Potion of Regeneration", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Slowness", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
-	{name: "Potion of Strength", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Combat]},
+	{name: "Potion of Strength", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Swiftness", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Weakness", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, Overworld, Combat]},
 	{name: "Potion of Leaping", infrequency: 12, reactant: ["Pacifist"], tags: [Item, Nether, RareBiome, Overworld, Combat]},


### PR DESCRIPTION
Fix for a tag bug [discussed in Discord](https://discord.com/channels/131720430326120449/1045020502621691985/1160398977141846026). Details are in the commit messages.