### PR TITLE
Add tabs to info section below bingo table

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -1042,7 +1042,7 @@ select, input[type="text"] {
 }
 
 .tabs-list a:is(:hover, :visited, :active) {
-	color: unset;
+	color: white;
 }
 
 .tabs-list a[aria-selected="true"] {
@@ -1050,7 +1050,8 @@ select, input[type="text"] {
 	text-decoration-thickness: 0.125em;
 	text-underline-offset: 0.875em;
 	padding-bottom: 1.25rem;
-	border-color: white;
+	border-color: var(--fg-colour);
+	color: var(--fg-colour);
 	border-bottom: none;
 	background-color: transparent;
 }

--- a/bingo.css
+++ b/bingo.css
@@ -1009,3 +1009,55 @@ select, input[type="text"] {
 	width: 48px;
 	height: 48px;
 }
+
+/*
+	Tabs
+*/
+
+.tabs-list {
+	display: flex;
+	justify-content: center;
+	align-items: end;
+	font-size: 1rem;
+	padding: 0 !important;
+}
+
+.tabs-list li {
+	display: contents;
+}
+
+.tabs-list a {
+	display: block;
+	flex-basis: 100%;
+	flex-grow: 1;
+	padding-block: 0.5rem;
+	background-color: black;
+	text-decoration: none;
+	color: white;
+	border: 2px solid #514f4d;
+}
+
+.tabs-list a:hover {
+	border-color: white;
+}
+
+.tabs-list a:is(:hover, :visited, :active) {
+	color: unset;
+}
+
+.tabs-list a[aria-selected="true"] {
+	text-decoration-line: underline;
+	text-decoration-thickness: 0.125em;
+	text-underline-offset: 0.875em;
+	padding-bottom: 1.25rem;
+	border-color: white;
+	border-bottom: none;
+	background-color: transparent;
+}
+
+.tab-panels > div {
+	/* Prevent big scroll reset when switching to smaller tabs */
+	min-height: 40vh;
+
+	padding-block: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 
 		<script src="https://code.jquery.com/jquery-3.6.0.js"></script>
 
+		<script defer src="tabs.js"></script>
 		<script src="Generators/generator_v1.js"></script>
 		<script src="Generators/generator_v2.js"></script>
 		<script src="Generators/generator_v3.js"></script>
@@ -165,16 +166,23 @@
 		<div class="stream-exit-text"><a href="#" onclick='toggleStreamerMode();event.preventDefault();'>Exit Streamer Mode</a> - <a href="#" onclick='popoutBingoCard();event.preventDefault();'>Pop out Bingo Card</a></div>
 		<div class="stream-exit-text"><a href="#" onclick='newSeed(true);event.preventDefault();'>Generate New Seed</a> - <a href="#" onclick='toggleHidden();event.preventDefault();'>Toggle Show/Hide</a></div>
 		<section id="rules-section">
-			<h2>Version</h2>
+			<ul class="tabs-list">
+				<li><a href="#panel-version" id="tab-version">Version</a></li>
+				<li><a href="#panel-how-to-play" id="tab-how-to-play">How to Play</a></li>
+				<li><a href="#panel-races" id="tab-races">Races</a></li>
+				<li><a href="#panel-other" id="tab-other">Other</a></li>
+			</ul>
+			<div class="tab-panels">
+				<div id="panel-version" aria-labelledby="tab-version">
 			<p>The various versions of the Bingo are designed for specific versions of Vanilla Minecraft (Java Edition, Bedrock versions have minor differences). Try to match versions whenever possible for the best experience.</p>
 			<p>To ensure that each created Bingo sheet always stays the same (even if goals are added or modified in the future) a version identifier is encoded into the URL.</p>
 			<p>Selected version: <select id="version_selection"></select></p>
 
 			<p id="version_notice">You are not using the latest stable version. This may be intended, for example if you want to look at a linked sheet or play on an older version of Minecraft. However, if you want to generate a new Bingo sheet, consider changing version.</p>
 			<p id="version_notice_unstable">You are using an in-development version which may change at any time causing the same link to produce different goals. This is good if you want to make use of the latest updates to goals and Minecraft and for looking at a sheet someone else just linked to you, otherwise consider changing to a stable version.</p>
+				</div>
 
-			<h2>How to Play</h2>
-
+				<div id="panel-how-to-play" aria-labelledby="tab-how-to-play">
 			<p>The objective is to get a "Bingo" as quickly as possible by completing the goals in five squares in a line horizontally, vertically or diagonally.</p>
 			<ul>
 				<li><strong>Items:</strong> Goals written as just Item names (such as "Iron Block" or "Milk Bucket") require you to get that item and have it in your Inventory at the end of the game. If you lose the item by completing the Bingo by dying (e.g. "Kill yourself with an Ender Pearl" as the last goal) you do not need to recollect the item.</li>
@@ -188,7 +196,9 @@
 			<p>Create a new world in Minecraft and use <input class="seed-input" id="seed_for_copying_howto" type="text" value="" size="6" readonly="readonly" /><button class="button small-button" title="Copy Seed to Clipboard" onclick='copySeedToClipboard("seed_for_copying_howto", event);'>Copy</button> as the Seed (this is the same random seed used to generate this sheet). Load the world so that it can generate but don't move until you're ready. Pause the game to make sure time of day doesn't change or you get attacked. When you're ready, reveal the sheet if it's hidden and start playing!</p>
 
 			<p><em>Note:</em> Third-party applications or mods (for example Optifine, MCEdit or online Seed Maps) are not allowed.</p>
+				</div>
 
+				<div id="panel-races" aria-labelledby="tab-races">
 			<h2><a href="https://therun.gg/" target="_blank"><span class="therun-logo"></span></a> Races <button class="button small-button" id="TheRunRefreshButton" title="(Re)Load race information from TheRung.gg." onclick="loadAndDisplayRaces()">Refresh</button></h2>
 			<p id="TheRunTip"><em>Tip:</em> Clicking a race will open the race page in a new tab. If a sheet is listed in the description it will load on this page and copy the seed to your clipboard.</p>
 			<p id="TheRunNoRaces">No races found, visit <a href="https://therun.gg/races" target="_blank">TheRun's race page</a> to start your own or view <a = href="https://therun.gg/races/stats/Minecraft%3A%20Java%20Edition/Bingo" target="_blank">MinecraftBingo race stats.</a></p>
@@ -203,11 +213,15 @@
 				</thead>
 				<tbody></tbody>
 			</table>
+				</div>
 
-			<h2>Other</h2>
-
+				<div id="panel-other" aria-labelledby="tab-other">
 			<p>These rules (and goal descriptions) represent the recommended way to play Minecraft Bingo, however if you play alone or everyone in the race agrees, then use whatever rules you want!</p>
 			<p>You can <a href="javascript:createGoalExport()">export the current sheet as JSON</a> for use in other tools such as <a href="https://bingosync.com/">Bingosync.</a></p>
+				</div>
+
+			</div>
+
 			<a href="https://github.com/Joshimuz/mcbingo"><span class="github-logo"></span></a>
 			<a href="https://joshimuz.com"><span class="joshimuz-logo"></span></a>
 		</section>

--- a/tabs.js
+++ b/tabs.js
@@ -1,0 +1,95 @@
+// Code from Kevin Powell's video and codepen: https://codepen.io/kevinpowell/pen/oNQgRKm
+// Slightly modified to work in minecraftbingo.com
+
+const tabsContainer = document.querySelector("#rules-section");
+const tabsList = tabsContainer.querySelector(".tabs-list");
+const tabPanels = tabsContainer.querySelectorAll(".tab-panels > div");
+const tabButtons = tabsList.querySelectorAll("a");
+
+tabsList.setAttribute("role", "tablist");
+
+tabsList.querySelectorAll("li").forEach((listitem) => {
+	listitem.setAttribute("role", "presentation");
+});
+
+tabButtons.forEach((tab, index) => {
+	tab.setAttribute("role", "tab");
+	if (index === 0) {
+		tab.setAttribute("aria-selected", "true");
+	} else {
+		tab.setAttribute("tabindex", "-1");
+		tabPanels[index].setAttribute("hidden", "");
+	}
+});
+
+tabPanels.forEach((panel) => {
+	panel.setAttribute("role", "tabpanel");
+	panel.setAttribute("tabindex", "0");
+});
+
+tabsList.addEventListener("click", (e) => {
+	const clickedTab = e.target.closest("a");
+	if (!clickedTab) return;
+	e.preventDefault();
+
+	switchTab(clickedTab);
+});
+
+tabsContainer.addEventListener("keydown", (e) => {
+	switch (e.key) {
+		case "ArrowLeft":
+			moveLeft();
+			break;
+		case "ArrowRight":
+			moveRight();
+			break;
+		case "Home":
+			e.preventDefault();
+			switchTab(tabButtons[0]);
+			break;
+		case "End":
+			e.preventDefault();
+			switchTab(tabButtons[tabButtons.length - 1]);
+			break;
+	}
+});
+
+function moveLeft() {
+	const currentTab = tabsList.querySelector("[aria-selected=true]");
+	if (!currentTab.parentElement.previousElementSibling) {
+		switchTab(tabButtons[tabButtons.length - 1]);
+	} else {
+		switchTab(
+			currentTab.parentElement.previousElementSibling.querySelector("a")
+		);
+	}
+}
+
+function moveRight() {
+	const currentTab = tabsList.querySelector("[aria-selected=true]");
+	if (!currentTab.parentElement.nextElementSibling) {
+		switchTab(tabButtons[0]);
+	} else {
+		switchTab(currentTab.parentElement.nextElementSibling.querySelector("a"));
+	}
+}
+
+function switchTab(newTab) {
+	const activePanelId = newTab.getAttribute("href");
+	const activePanel = tabsContainer.querySelector(activePanelId);
+
+	tabButtons.forEach((button) => {
+		button.setAttribute("aria-selected", false);
+		button.setAttribute("tabindex", "-1");
+	});
+
+	tabPanels.forEach((panel) => {
+		panel.setAttribute("hidden", true);
+	});
+
+	activePanel.removeAttribute("hidden", false);
+
+	newTab.setAttribute("aria-selected", true);
+	newTab.setAttribute("tabindex", "0");
+	newTab.focus();
+}


### PR DESCRIPTION
[Josh said](https://www.youtube.com/watch?v=Jt8d527iYGc&t=36000s) he wanted to put the information below the bingo table behind tabs so I did it. You can check out a live version using the tabs [here](https://cvenencia.github.io/mcbingo/).

<img width="875" height="479" alt="Captura de pantalla 2025-12-19 174444" src="https://github.com/user-attachments/assets/4a9d3a5c-bdbc-43c4-a908-43c3b78ea032" />

The tabs implementation comes from Kevin Powell's [video](https://youtu.be/fI9VM5zzpu8?si=wEnrHj3wsYXLN86V) and [codepen](https://codepen.io/kevinpowell/pen/oNQgRKm). I made small modifications just to make it work here.

You can navigate the tabs by either clicking on them, or focusing anywhere inside the `section#rules-section` element and pressing right or left arrow. I made sure this doesn't interfere with any of the current interactable elements inside for accessibility reasons.

I added the tabs functionality to a new file (`tabs.js`). Also tried to minimize the changes to `index.html` to avoid possible merge conflicts by not indenting the sections that were already there, so indentation is a bit broken in the sections I updated.

I can make further changes as required.
