### PR TITLE
Changed "whilst" death message to "while" (see MC-252295)

### DIFF
--- a/Goals/goals_v5.js
+++ b/Goals/goals_v5.js
@@ -549,7 +549,7 @@ var bingoList_v5 = [
 	{name: "Grow a Mega Jungle Tree", difficulty: 13, tooltiptext: "A mega tree is one grown with a 2x2 square of saplings.", tags: [Action, RareBiome, Overworld]},
 	{name: "Kill a hostile mob with Gravel", difficulty: 13, reactant: ["Pacifist"], antisynergy: ["KillFallingBlock"], infrequency: 2, tags: [Action, Combat]},
 	{name: "Bounce on a Slime Block", difficulty: 17, tooltiptext: "Get a Slime Block, place it on the ground and give it a good old bouncin' on.", tooltipimg: "SlimeBlock.jpg", tags: [Action, Overworld, RareBiome]},
-	{name: "Get a '... whilst trying to escape ...' Death message", difficulty: 14, tooltiptext: "Example: 'PLAYER' drowned whilst trying to escape a Skeleton.", tags: [Action, Death]},
+	{name: "Get a '... while trying to escape ...' Death message", difficulty: 14, tooltiptext: "Example: 'PLAYER' drowned while trying to escape a Skeleton.", tags: [Action, Death]},
 	{name: "Feed a Cookie to a Parrot", difficulty: 16, reactant: ["Pacifist"], infrequency: 2, tags: [Action, RareBiome, Overworld]},
 	{name: "Tame a Parrot", difficulty: 14, infrequency: 2, tags: [Action, RareBiome, Overworld]},
 	{name: "Kill a hostile mob with Sand", difficulty: 14, reactant: ["Pacifist"], antisynergy: ["KillFallingBlock"], infrequency: 2, tags: [Action, Combat, Overworld]},

--- a/Goals/goals_v6.js
+++ b/Goals/goals_v6.js
@@ -551,7 +551,7 @@ var bingoList_v6 = [
 	{name: "Grow a Mega Jungle Tree", difficulty: 13, tooltiptext: "A mega tree is one grown with a 2x2 square of saplings.", tags: [Action, RareBiome, Overworld]},
 	{name: "Kill a hostile mob with Gravel", difficulty: 13, reactant: ["Pacifist"], antisynergy: ["KillFallingBlock"], infrequency: 2, tags: [Action, Combat]},
 	{name: "Bounce on a Slime Block", difficulty: 17, tooltiptext: "Get a Slime Block, place it on the ground and give it a good old bouncin' on.", tooltipimg: "SlimeBlock.jpg", tags: [Action, Overworld, RareBiome]},
-	{name: "Get a '... whilst trying to escape ...' Death message", difficulty: 14, tooltiptext: "Example: 'PLAYER' drowned whilst trying to escape a Skeleton.", tags: [Action, Death]},
+	{name: "Get a '... while trying to escape ...' Death message", difficulty: 14, tooltiptext: "Example: 'PLAYER' drowned while trying to escape a Skeleton.", tags: [Action, Death]},
 	{name: "Feed a Cookie to a Parrot", difficulty: 16, reactant: ["Pacifist"], infrequency: 2, tags: [Action, RareBiome, Overworld]},
 	{name: "Tame a Parrot", difficulty: 14, infrequency: 2, tags: [Action, RareBiome, Overworld]},
 	{name: "Kill a hostile mob with Sand", difficulty: 14, reactant: ["Pacifist"], antisynergy: ["KillFallingBlock"], infrequency: 2, tags: [Action, Combat, Overworld]},


### PR DESCRIPTION
**Alternative title:**  Deprecation of proper english (sorry Josh 😞)

Since `1.20.2 Pre-release 1` the death messages "... whilst trying to escape ..." have been changed to "... while trying to escape ...".   
This may seem nitpicky, but I had a mini heart attack after doing this as my last goal, thinking I had done the wrong thing 😅 

References:  
* [MC-252295](https://bugs.mojang.com/browse/MC/issues/MC-252295)
* [Death Messages](https://minecraft.wiki/w/Death_messages) (its not updated in the list of messages, but mentioned in the history at the bottom)