### PR TITLE
define html background color for ranges outside the body

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -74,7 +74,7 @@ button:focus, input:focus {
 
 /** backgrounds **/
 html {
-	background-color: var(--bg-colour);
+	background-color: #141414;
 }
 body {
 	background-color: var(--bg-colour);

--- a/bingo.css
+++ b/bingo.css
@@ -73,6 +73,9 @@ button:focus, input:focus {
 }
 
 /** backgrounds **/
+html {
+	background-color: var(--bg-colour);
+}
 body {
 	background-color: var(--bg-colour);
 	background-size: 1920px 1080px;


### PR DESCRIPTION
in dark mode: scrolling outside the defined 1080p body you can see the html-class default white flash through.
seems like html cannot inherit the .dark class from theme toggle.